### PR TITLE
add utf-8, consistent smart quotes and symbols

### DIFF
--- a/DOL.WHD.Section14c.Web/index.html
+++ b/DOL.WHD.Section14c.Web/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html ng-app="14c" lang="en">
 <head>
+    <meta charset="utf-8">
     <title>DOL WHD Section 14c</title>
 </head>
 <body>

--- a/DOL.WHD.Section14c.Web/index.html
+++ b/DOL.WHD.Section14c.Web/index.html
@@ -2,6 +2,7 @@
 <html ng-app="14c" lang="en">
 <head>
     <meta charset="utf-8">
+    <meta http-equiv=Content-Type content="text/html; charset=utf-8">
     <title>DOL WHD Section 14c</title>
 </head>
 <body>

--- a/DOL.WHD.Section14c.Web/src/modules/components/formFooterControls/formFooterControlsTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/formFooterControls/formFooterControlsTemplate.html
@@ -2,7 +2,6 @@
     <div class="button-group">
         <button class="back-button" ng-show="vm.hasBack" ng-click="vm.onBackClick()">{{ vm.backLabel }}</button>
         <div class="pull-right">
-            <!--<button class="save-button" ng-click="vm.onSaveClick()">Save &amp; Continue Later</button>-->
             <button class="next-button" ng-click="vm.onNextClick()">{{ vm.nextLabel }}</button>
         </div>
     </div>

--- a/DOL.WHD.Section14c.Web/src/modules/components/resetPasswordForm/resetPasswordFormTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/resetPasswordForm/resetPasswordFormTemplate.html
@@ -45,7 +45,7 @@
                         <li><span class="checkmark" ng-class="vm.passwordLower ? 'checked' : ''"></span>Contain at least 1 lowercase leter.</li>
                         <li><span class="checkmark" ng-class="vm.passwordSpecial ? 'checked' : ''"></span>Contain at least 1 special character.</li>
                         <li><span class="checkmark" ng-class="vm.passwordNumber ? 'checked' : ''"></span>Contain at least 1 number.</li>
-                        <li><span class="checkmark" ng-class="passwordStrength.score > 2 ? 'checked' : ''"></span>Meets "Good" password strength.</li>
+                        <li><span class="checkmark" ng-class="passwordStrength.score > 2 ? 'checked' : ''"></span>Meets “Good” password strength.</li>
                     </ul>
                     </p>
                 </div>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionAdminEmployer/sectionAdminEmployerTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionAdminEmployer/sectionAdminEmployerTemplate.html
@@ -19,7 +19,7 @@
     </answer-field>
 
     <answer-field answer="appData.employer.legalNameHasChanged">
-        Has the Employer's legal name changed since its last application?
+        Has the Employer’s legal name changed since its last application?
     </answer-field>
 
     <answer-field answer="appData.employer.priorLegalName" ng-show="appData.employer.legalNameHasChanged">
@@ -27,7 +27,7 @@
     </answer-field>
 
     <answer-field answer="appData.employer.physicalAddress" address-field="true">
-        Physical Address of Employer's Main Establishment
+        Physical Address of Employer’s Main Establishment
     </answer-field>
 
     <answer-field answer="appData.employer.hasParentOrg">
@@ -68,7 +68,7 @@
     <hr>
 
     <answer-field answer="appData.employer.fiscalQuarterEndDate" datefield="true">
-        When did the Employer's most recently completed fiscal quarter end?
+        When did the Employer’s most recently completed fiscal quarter end?
     </answer-field>
 
     <answer-field answer="appData.employer.numSubminimalWageWorkers.total">
@@ -148,5 +148,4 @@
     <answer-field answer="appData.employer.temporaryAuthority">
         Is this a request for Temporary Authority?
     </answer-field>
-
 </div>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionAdminWorkSites/adminWorkSiteDetailTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionAdminWorkSites/adminWorkSiteDetailTemplate.html
@@ -1,5 +1,5 @@
 <div class="admin-page">
-    <h1>Work Sites &amp; Employees</h1>
+    <h1>Work Sites & Employees</h1>
     <hr>
 
     <div class="form-tabbed-section">
@@ -32,7 +32,7 @@
             Total number of employees who were employed at this establishment/work site at any time during the most recently completed fiscal quarter and received subminimum wages:
         </answer-field>
         <div class="form-footer-controls">
-            <button class="blue-button" ng-click="vm.viewAllWorkSites()">View All Work Sites &amp; Employees</button>
+            <button class="blue-button" ng-click="vm.viewAllWorkSites()">View All Work Sites & Employees</button>
             <button class="green-button pull-right" ng-click="vm.setActiveTab(2)">View Employees</button>
         </div>
     </div>
@@ -75,7 +75,7 @@
 
         <div class="form-footer-controls">
             <button class="green-button nomargin" ng-click="vm.setActiveTab(1)">View Work Site</button>
-            <button class="blue-button pull-right" ng-click="vm.viewAllWorkSites()">View All Work Sites &amp; Employees</button>
+            <button class="blue-button pull-right" ng-click="vm.viewAllWorkSites()">View All Work Sites & Employees</button>
         </div>
     </div>
 </div>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionAdminWorkSites/sectionAdminWorkSitesTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionAdminWorkSites/sectionAdminWorkSitesTemplate.html
@@ -1,6 +1,6 @@
 <div class="admin-page">
     <div class="dol-form-section-title">
-        <h2>Worksites &amp; Employees</h2>
+        <h2>Worksites & Employees</h2>
     </div>
         
     <answer-field answer="$parent.appData.totalNumWorkSites">

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionEmployer/sectionEmployerTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionEmployer/sectionEmployerTemplate.html
@@ -53,7 +53,7 @@
         </div>
     </div>
     <div class="form-question-block" ng-class="validate('employer.legalNameHasChanged') ? 'usa-input-error' : ''">
-        <div class="form-question-text">Has the Employer's name(s) changed since its last application?
+        <div class="form-question-text">Has the Employer’s name(s) changed since its last application?
         </div>
         <span class="usa-input-error-message" role="alert" ng-show="validate('employer.legalNameHasChanged')">{{ validate('employer.legalNameHasChanged') }}</span>
         <fieldset class="usa-fieldset-inputs form-question-answer">
@@ -77,7 +77,7 @@
         </div>
     </div>
     <div class="form-question-block">
-        <div class="form-question-text">Physical Address of Employer's Main Establishment</div>
+        <div class="form-question-text">Physical Address of Employer’s Main Establishment</div>
         <fieldset class="usa-form-large">
             <div ng-class="validate('employer.physicalAddress.streetAddress') ? 'usa-input-error' : ''">
                 <label for="mailing-address-1">Street Address</label>
@@ -119,7 +119,7 @@
     </div>
 
     <div class="form-question-block" ng-show="formData.employer.hasMailingAddress === true">
-        <div class="form-question-text">Mailing Address of Employer's Main Establishment</div>
+        <div class="form-question-text">Mailing Address of Employer’s Main Establishment</div>
         <fieldset>
             <div class="usa-form-large">
                 <div ng-class="validate('employer.mailingAddress.streetAddress') ? 'usa-input-error' : ''">
@@ -162,7 +162,7 @@
     <div class="form-question-block" ng-class="validate('employer.hasParentOrg') ? 'usa-input-error' : ''">
         <div class="form-question-text">Does the Employer have a Parent Organization?
             <helplink></helplink>
-            <helptext>SWEPs should enter the school district's information in Item 4.</helptext>
+            <helptext>SWEPs should enter the school district’s information in Item 4.</helptext>
         </div>
         <span class="usa-input-error-message" role="alert" ng-show="validate('employer.hasParentOrg')">{{ validate('employer.hasParentOrg') }}</span>
         <fieldset class="usa-fieldset-inputs form-question-answer">
@@ -232,7 +232,7 @@
     <div class="form-question-block" ng-class="validate(['employer.employerStatusId', 'employer.employerStatusOther']) ? 'usa-input-error' : ''">
         <div class="form-question-text">Employer Status
             <helplink></helplink>
-            <helptext>Select the option that describes the employer's status. For example, a SWEP operated by a public school system should select "Public."</helptext>
+            <helptext>Select the option that describes the employer’s status. For example, a SWEP operated by a public school system should select “Public.”</helptext>
         </div>
         <span class="usa-input-error-message" role="alert" ng-show="validate('employer.employerStatusId')">{{ validate('employer.employerStatusId') }}</span>
         <fieldset class="usa-fieldset-inputs form-question-answer">
@@ -249,9 +249,8 @@
     <div class="form-question-block" ng-class="validate('employer.isEducationalAgency') ? 'usa-input-error' : ''">
         <div class="form-question-text">Is this employer a local or State educational agency?
             <helplink></helplink>
-            <helptext>The term "local educational agency" means a public board of education or other public authority legally constituted within a State for either administrative control or direction of, or to perform a service function for, public elementary schools or secondary schoolsin a city, county, township, school district, or other political subdivision of a State, or of or for a combination of school districts orcounties that is recognized in a State as an administrative agency for its public elementary schools or secondary schools. The term "State educational agency" means the agency primarily responsible for the State supervision of public elementary schoolsand secondary schools. See 20 U.S.C. 7801, the Elementary and Secondary Education Act of 1965.</helptext>
+            <helptext>The term “local educational agency” means a public board of education or other public authority legally constituted within a State for either administrative control or direction of, or to perform a service function for, public elementary schools or secondary schools in a city, county, township, school district, or other political subdivision of a State, or of or for a combination of school districts or counties that is recognized in a State as an administrative agency for its public elementary schools or secondary schools. The term “State educational agency” means the agency primarily responsible for the State supervision of public elementary schoolsand secondary schools. See 20 U.S.C. 7801, the Elementary and Secondary Education Act of 1965.</helptext>
         </div>
-        <div class="form-question-subtext">The term "local educational agency" means a public board of education or other public authority legally constituted within a State... [See More]</div>
         <span class="usa-input-error-message" role="alert" ng-show="validate('employer.isEducationalAgency')">{{ validate('employer.isEducationalAgency') }}</span>
         <fieldset class="usa-fieldset-inputs form-question-answer">
             <ul class="usa-unstyled-list">
@@ -270,9 +269,9 @@
         <h3>Number of Workers With Disabilities</h3>
         <hr />
         <div class="form-question-block" ng-class="validate('employer.fiscalQuarterEndDate') ? 'usa-input-error' : ''">
-            <div class="form-question-text">When did the Employer's most recently completed fiscal quarter end?
+            <div class="form-question-text">When did the Employer’s most recently completed fiscal quarter end?
                 <helplink></helplink>
-                <helptext>Provide the ending date of the employer's most recently completed three-month fiscal quarter. For example, if the fiscal year begins on January 1, provide the date of the most recently completed quarter (March 31, June 30, September 30, or December 31).</helptext>
+                <helptext>Provide the ending date of the employer’s most recently completed three-month fiscal quarter. For example, if the fiscal year begins on January 1, provide the date of the most recently completed quarter (March 31, June 30, September 30, or December 31).</helptext>
             </div>
             <span class="usa-input-error-message" role="alert" ng-show="validate('employer.fiscalQuarterEndDate')">{{ validate('employer.fiscalQuarterEndDate') }}</span>
             <fieldset>
@@ -347,9 +346,9 @@
         </fieldset>
     </div>
     <div class="form-question-block" ng-class="validate('employer.scaId') ? 'usa-input-error' : ''">
-        <div class="form-question-text">Does this employer currently hold any contracts covered by the McNamara-O'Hara Service Contract Act (SCA)?
+        <div class="form-question-text">Does this employer currently hold any contracts covered by the McNamara-O’Hara Service Contract Act (SCA)?
             <helplink></helplink>
-            <helptext>Make the appropriate selection if the employer has, or intends to receive, any contracts with the McNamara-O'Hara Service Contract Act (SCA). If the employer had one or more SCA-covered. Additional information about contracts with the Federal Government can be found at <a href="www.dol.gov/whd/govcontracts/">www.dol.gov/whd/govcontracts/</a>.</helptext>
+            <helptext>Make the appropriate selection if the employer has, or intends to receive, any contracts with the McNamara-O’Hara Service Contract Act (SCA). If the employer had one or more SCA-covered. Additional information about contracts with the Federal Government can be found at <a href="www.dol.gov/whd/govcontracts/">www.dol.gov/whd/govcontracts/</a>.</helptext>
         </div>
         <span class="usa-input-error-message" role="alert" ng-show="validate('employer.scaId')">{{ validate('employer.scaId') }}</span>
         <fieldset class="usa-fieldset-inputs form-question-answer">
@@ -423,7 +422,7 @@
     <div class="form-question-block" ng-class="validate('employer.takeCreditForCosts') ? 'usa-input-error' : ''">
         <div class="form-question-text">Did the employer take credit for the cost of providing facilities, such as board, lodging, and transportation, toward meeting the minimum wage or subminimum wage obligations during the most recently completed fiscal quarter?
             <helplink></helplink>
-            <helptext>Indicate if the employer provided facilities such as lodging, board, and transportation to any employee, and took credit for those costs toward meeting the minimum wage or subminimum wage obligations to employees with disabilities during the most recently completed fiscal quarter. See 29 C.F.R. § 531 and 29 C.F.R. &sect; 516.</helptext>
+            <helptext>Indicate if the employer provided facilities such as lodging, board, and transportation to any employee, and took credit for those costs toward meeting the minimum wage or subminimum wage obligations to employees with disabilities during the most recently completed fiscal quarter. See 29 C.F.R. § 531 and 29 C.F.R. § 516.</helptext>
         </div>
         <span class="usa-input-error-message" role="alert" ng-show="validate('employer.takeCreditForCosts')">{{ validate('employer.takeCreditForCosts') }}</span>
         <fieldset class="usa-fieldset-inputs form-question-answer">

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionReview/sectionReviewTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionReview/sectionReviewTemplate.html
@@ -1,6 +1,6 @@
 <div class="form-page-full" ng-hide="vm.submissionSuccess">
     <h2>Review & Submit</h2>
-    <p>We've checked your responses from each section to make sure there were no errors or missing information before submission.</p>
+    <p>We’ve checked your responses from each section to make sure there were no errors or missing information before submission.</p>
     <p>Below is a summary of the results:</p>
 
     <div class="section-results">
@@ -48,10 +48,10 @@
     <hr>
 
     <div class="section-results">
-        <h3>Work Sites &amp; Employees</h3>
+        <h3>Work Sites & Employees</h3>
         <reviewbar errorstate="{{ validation.__worksites }}"></reviewbar>
         <div ng-hide="validation.__worksites">
-            <a href="" ng-click="navService.gotoSection('work-sites')">Review Work Sites &amp; Employees</a>
+            <a href="" ng-click="navService.gotoSection('work-sites')">Review Work Sites & Employees</a>
         </div>
         <button ng-click="navService.gotoSection('work-sites')" ng-show="validation.__worksites">Edit Responses</button>
     </div>
@@ -69,7 +69,6 @@
 
     <div class="usa-alert usa-alert-error" role="alert" ng-show="vm.submissionError">
         <div class="usa-alert-body">
-            <!--<h3 class="usa-alert-heading">Error Status</h3>-->
             <p class="usa-alert-text">An error occurred while submitting your application. Please try again later if the error persists:</p>
             <p class="usa-alert-text">{{ "ERROR " + vm.submissionError.status + ":  " + (vm.submissionError.data.error_description ? vm.submissionError.data.error_description : "unknown error") }}</p>
         </div>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/sectionWageDataTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/sectionWageDataTemplate.html
@@ -50,10 +50,10 @@
         <a href="https://www.dol.gov/whd/sec14c/calculators/90-10-Task_Var_Units.htm" target="_blank">90/10 Form, Fixed Time, Variable Units</a><br>
         <br>
         Piece Rate - Number of Units in Standard Calculators:<br>
-        <a href="https://www.dol.gov/whd/sec14c/calculators/FixedUnit_VariableTime9.htm" target="_blank">Fixed Number of Units, PF&amp;D 9 min</a><br>
-        <a href="https://www.dol.gov/whd/sec14c/calculators/FixedUnit_VariableTime10.htm" target="_blank">Fixed Number of Units, PF&amp;D 10 min</a><br>
-        <a href="https://www.dol.gov/whd/sec14c/calculators/FixedTime_VariableUnit9.htm" target="_blank">Fixed Time, PF&amp;D 9 min</a><br>
-        <a href="https://www.dol.gov/whd/sec14c/calculators/FixedTime_VariableUnit10.htm" target="_blank">Fixed Time, PF&amp;D 10 min</a><br>
+        <a href="https://www.dol.gov/whd/sec14c/calculators/FixedUnit_VariableTime9.htm" target="_blank">Fixed Number of Units, PF&D 9 min</a><br>
+        <a href="https://www.dol.gov/whd/sec14c/calculators/FixedUnit_VariableTime10.htm" target="_blank">Fixed Number of Units, PF&D 10 min</a><br>
+        <a href="https://www.dol.gov/whd/sec14c/calculators/FixedTime_VariableUnit9.htm" target="_blank">Fixed Time, PF&D 9 min</a><br>
+        <a href="https://www.dol.gov/whd/sec14c/calculators/FixedTime_VariableUnit10.htm" target="_blank">Fixed Time, PF&D 10 min</a><br>
         <a href="https://www.dol.gov/whd/sec14c/calculators/PieceRate.htm" target="_blank">Piece Rate Calculator</a><br>
         <br>
         New Minimum Wage Calculator<br>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/wageDataPayTypeFormTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/wageDataPayTypeFormTemplate.html
@@ -86,9 +86,6 @@
                                 <input id="mailing-address-1" name="mailing-address-1" type="text" ng-model="vm.activeSourceEmployer.address.streetAddress">
                             </div>
 
-                          <!--<label for="mailing-address-2">Street address 2 <span class="usa-additional_text">Optional</span></label>
-                          <input id="mailing-address-2" name="mailing-address-2" type="text">-->
-
                           <div class="clearer" ng-class="vm.validateActiveSourceEmployerProperty('address.city') || vm.validateActiveSourceEmployerProperty('address.state') ? 'usa-input-error' : ''">
                             <div class="usa-input-grid usa-input-grid-medium">
                               <label for="city">City</label>
@@ -374,13 +371,13 @@
                 <helptext>Attach all documentation of the methods used to determine the standard productivity and the piece rate, such as:
                     <ul>
                         <li>detailed task analysis (including quality and quantity measures), and</li>
-                        <li>productivity of an experienced worker who is not disabled for the work performing the same job (i.e., "standard setter").</li>
+                        <li>productivity of an experienced worker who is not disabled for the work performing the same job (i.e., “standard setter”).</li>
                     </ul>
                 </helptext>
             </div>
             <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.attachmentId')">{{ validate(modelPrefix() + '.attachmentId') }}</span>
             <div class="form-question-answer">
-                <span>Examples include detailed task analysis(including quality and quantity measures), and productivity of an experienced worker who is not disabled for the work performing the same job (i.e. "standard setter").</span>
+                <span>Examples include detailed task analysis(including quality and quantity measures), and productivity of an experienced worker who is not disabled for the work performing the same job (i.e. “standard setter”).</span>
                 <attachment-field attachment-id="formData[modelPrefix()].attachmentId" attachment-name="formData[modelPrefix()].attachmentName" />
             </div>
         </div>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionWorkSites/sectionWorkSitesTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionWorkSites/sectionWorkSitesTemplate.html
@@ -1,5 +1,5 @@
 <div class="dol-form-section-title">
-    <h2>Work Sites &amp; Employees</h2>
+    <h2>Work Sites & Employees</h2>
 
     <div class="dol-form-section-help">
         <ul>
@@ -25,9 +25,9 @@
     </div>
 
     <div class="form-question-block" ng-class="validate('workSites') ? 'usa-input-error' : ''">
-        <div class="form-question-text">We'll need to collect information about each worksite and its employees.</div>
+        <div class="form-question-text">We’ll need to collect information about each worksite and its employees.</div>
         <span class="usa-input-error-message" role="alert" ng-show="validate('workSites')">{{ validate('workSites') }}</span>
-        <button ng-click="vm.addWorkSite()" ng-hide="vm.addingWorkSite">Add Work Site &amp; Employee(s)</button>
+        <button ng-click="vm.addWorkSite()" ng-hide="vm.addingWorkSite">Add Work Site & Employee(s)</button>
     </div>
 
     <div id="worksite_tab_box" class="form-tabbed-section" ng-show="vm.notInitialApp() && vm.addingWorkSite">
@@ -37,7 +37,7 @@
 
     <!-- Tab 1 (Add Work Site) -->
     <div class="form-spaced-div" ng-show="vm.addingWorkSite && vm.activeTab === 1">
-        <div>First, we'll collect information about the Work Site / Establishment.</div>
+        <div>First, we’ll collect information about the Work Site / Establishment.</div>
 
         <div class="form-question-block" ng-class="vm.validateActiveWorksiteProperty('type') ? 'usa-input-error' : ''">
             <div class="form-question-text">What type of establishment is this?
@@ -83,9 +83,6 @@
                             <span class="usa-input-error-message" role="alert" ng-show="vm.validateActiveWorksiteProperty('address.streetAddress')">{{ vm.validateActiveWorksiteProperty('address.streetAddress') }}</span>
                             <input id="worksiteAddress1" name="worksiteAddress1" type="text" ng-model="vm.activeWorksite.address.streetAddress">
                         </div>
-
-                        <!--<label for="worksiteAddress2">Street address 2 <span class="usa-additional_text">Optional</span></label>
-                        <input id="worksiteAddress2" name="worksiteAddress2" type="text" ng-model="vm.activeWorksite.address.streetAddress2">-->
 
                     <div class="clearer" ng-class="vm.validateActiveWorksiteProperty('address.city') || vm.validateActiveWorksiteProperty('address.state') ? 'usa-input-error' : ''">
                     <div class="usa-input-grid usa-input-grid-medium">
@@ -136,7 +133,7 @@
         <div class="form-question-block" class="form-question-block" ng-class="vm.validateActiveWorksiteProperty('federalContractWorkPerformed') ? 'usa-input-error' : ''">
             <div class="form-question-text">Is work performed at this establishment / work site pursuant to a Federal contract for services or concessions that was entered into on or after January 1, 2015, which indicates that the contract may be subject to Executive Order 13658 (Establishing a Minimum Wage for Contractors)?
                 <helplink></helplink>
-                <helptext>Mark "yes" if the employer has a contract with the Federal Government for services or concessions that was entered into on or after January 1, 2015, which indicates that the contract may be subject to <a href='https://www.federalregister.gov/documents/2014/02/20/2014-03805/establishing-a-minimum-wage-for-contractors' target='_blank'>Executive Order 13658</a> (Establishing a Minimum Wage for Contractors).</helptext>
+                <helptext>Mark “yes” if the employer has a contract with the Federal Government for services or concessions that was entered into on or after January 1, 2015, which indicates that the contract may be subject to <a href='https://www.federalregister.gov/documents/2014/02/20/2014-03805/establishing-a-minimum-wage-for-contractors' target='_blank'>Executive Order 13658</a> (Establishing a Minimum Wage for Contractors).</helptext>
             </div>
             <span class="usa-input-error-message" role="alert" ng-show="vm.validateActiveWorksiteProperty('federalContractWorkPerformed')">{{ vm.validateActiveWorksiteProperty('federalContractWorkPerformed') }}</span>
             <div class="form-question-answer">
@@ -175,13 +172,13 @@
         </div>
 
         <div class="form-spaced-div">
-            <p>We'll need collect specific information for each employee.</p>
+            <p>We’ll need collect specific information for each employee.</p>
             <p><a href="" ng-click="vm.showEmployeeInfoHelp = !vm.showEmployeeInfoHelp">See detailed instructions on employee information</a></p>
 
             <div class="dol-help-employee-info" ng-show="vm.showEmployeeInfoHelp">
                 <ul>
                     <li><span>Full Name of Worker</span><span>Provide the full name of the worker.</span></li>
-                    <li><span>Primary Disability</span><span>Identify the primary disability that affects the worker's productivity for the job identified using the categories provided.</span></li>
+                    <li><span>Primary Disability</span><span>Identify the primary disability that affects the worker’s productivity for the job identified using the categories provided.</span></li>
                     <li><span>Type of Work</span><span><p>Descibe the work peformed by this worker in the job for which the worker worked the most number of hours at a subminimum wage.</p><p>Examples may include: sewing, janitorial, box assembly, laundry, etc.</p></span></li>
                     <li><span>Number of Jobs</span><span>If the worker performed more than one job at this work site during the most recently compelted fiscal quarter provide the total number of jobs.</span></li>
                     <li><span>Average Hours per Week</span>
@@ -195,25 +192,25 @@
                         <span>
                             <p>Average earnings are computed by dividing the total earnings of the individual worker by the total number of hours worked during the most recently completed fiscal quarter.</p>
                             <p>Note:The total number of hours worked should only include the compensable work time (for example: generally would not include time spent in rehabilitation, therapy, etc.)</p>
-                            <p>For example, John Jones earned $900 during the fiscal quarter and he worked 300 hours. $900 ÷ 300 hours = $3.00 per hour, therefore, Mr. Jones's average earnings per hour are $3.00.</p>
+                            <p>For example, John Jones earned $900 during the fiscal quarter and he worked 300 hours. $900 ÷ 300 hours = $3.00 per hour, therefore, Mr. Jones’s average earnings per hour are $3.00.</p>
                         </span>
                     </li>
                     <li><span>Prevailing Wage</span><span>Provide the prevailing wage rate for the job identified.</span></li>
                     <li><span>Productivity Measure</span>
                         <span>
-                            <p>Provide the employee's most recent productivity rating the job identified.</p>
-                            <p>For work paid hourly, the productivity rating is the employee's productivity in proportion to the standard-setter's that was determined by the employee's time study.</p>
-                            <p>For piece rate work, no calculation is required, choose "n/a - piece rate".</p>
+                            <p>Provide the employee’s most recent productivity rating the job identified.</p>
+                            <p>For work paid hourly, the productivity rating is the employee’s productivity in proportion to the standard-setter’s that was determined by the employee’s time study.</p>
+                            <p>For piece rate work, no calculation is required, choose “n/a - piece rate”.</p>
                         </span>
                     </li>
                     <li><span>Commensurate Wage Rate</span>
                         <span>
-                            <p>For work paid hourly, provide the employee's commensurate wage rate per hour for the job identified. This should be the wage rate actually paid to the worker for this job.</p>
-                            <p>For piece rate work, provide the employee's average earnings per hour for the job identified.</p>
+                            <p>For work paid hourly, provide the employee’s commensurate wage rate per hour for the job identified. This should be the wage rate actually paid to the worker for this job.</p>
+                            <p>For piece rate work, provide the employee’s average earnings per hour for the job identified.</p>
                         </span>
                     </li>
-                    <li><span>Total Hours</span><span>Provide the employee's total hours worked on the job identified over the most recently completed fiscal quarter.</span></li>
-                    <li><span>Work at Other Site?</span><span>Answer "yes" if the employee also performed work at another work site included with this application. You must add the worker for each work site they worked at.</span></li>
+                    <li><span>Total Hours</span><span>Provide the employee’s total hours worked on the job identified over the most recently completed fiscal quarter.</span></li>
+                    <li><span>Work at Other Site?</span><span>Answer “yes” if the employee also performed work at another work site included with this application. You must add the worker for each work site they worked at.</span></li>
                 </ul>
             </div>
 

--- a/DOL.WHD.Section14c.Web/src/modules/components/userRegistrationForm/userRegistrationFormTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/userRegistrationForm/userRegistrationFormTemplate.html
@@ -4,8 +4,8 @@
         <ul>
             <li>All employers, including current Certificate Holders, previous Certificate Holders and new applicants,
                 will have to create an account in order to submit the form electronically.</li>
-            <li>The Employer's EIN is required to create an account.</li>
-            <li>Once the Employer's account is created, additional users can be added.</li>
+            <li>The Employer’s EIN is required to create an account.</li>
+            <li>Once the Employer’s account is created, additional users can be added.</li>
             <li>The electronic form includes both form WH-226 and WH-226A.</li>
         </ul>
         <p>Read our <a href="#">FAQs for Electronic Section 14(c) Certificate Application</a>.</p>
@@ -69,7 +69,7 @@
                 <li><span class="checkmark" ng-class="vm.passwordLower ? 'checked' : ''"></span>Contain at least 1 lowercase leter.</li>
                 <li><span class="checkmark" ng-class="vm.passwordSpecial ? 'checked' : ''"></span>Contain at least 1 special character.</li>
                 <li><span class="checkmark" ng-class="vm.passwordNumber ? 'checked' : ''"></span>Contain at least 1 number.</li>
-                <li><span class="checkmark" ng-class="passwordStrength.score > 2 ? 'checked' : ''"></span>Meets "Good" password strength</li>
+                <li><span class="checkmark" ng-class="passwordStrength.score > 2 ? 'checked' : ''"></span>Meets “Good” password strength</li>
             </ul>
             </p>
         </div>


### PR DESCRIPTION
this PR addresses https://github.com/18F/dol-whd-14c/issues/123

i explicitly enabled the `utf-8` charset for `index.html`

smart quotes were not used consistently through the content sections in the app; some had them while others did not (to see the difference: http://smartquotesforsmartpeople.com/). i think i tracked them all down and updated.

also, "named HTML entities" were sometimes used for symbols (i.e., "&sect;" for "§") while other times, the symbol itself was used -- i normalized this to just use the symbols in the markup