### PR TITLE
UI component page (to facilitate 508 testing)

### DIFF
--- a/DOL.WHD.Section14c.Web/env.js
+++ b/DOL.WHD.Section14c.Web/env.js
@@ -1,8 +1,8 @@
 (function(window) {
   window.__env = window.__env || {};
   Object.assign(window.__env, {
-    api_url: 'https://dol-whd-section14c-api-stg.azurewebsites.net',
-    reCaptchaSiteKey: '6Lc7OA4UAAAAADghnfWwelZ6XPtBUDAnywKtW0xl',
+    api_url: 'https://localhost:44399',
+    reCaptchaSiteKey: '6LeqeggUAAAAALC5zT4OHbDJk9gHNT0GGZbJMOnG',
     requireHttps: true,
     tokenCookieDurationMinutes: 20160
   });

--- a/DOL.WHD.Section14c.Web/env.js
+++ b/DOL.WHD.Section14c.Web/env.js
@@ -1,8 +1,8 @@
 (function(window) {
   window.__env = window.__env || {};
   Object.assign(window.__env, {
-    api_url: 'https://localhost:44399',
-    reCaptchaSiteKey: '6LeqeggUAAAAALC5zT4OHbDJk9gHNT0GGZbJMOnG',
+    api_url: 'https://dol-whd-section14c-api-stg.azurewebsites.net',
+    reCaptchaSiteKey: '6Lc7OA4UAAAAADghnfWwelZ6XPtBUDAnywKtW0xl',
     requireHttps: true,
     tokenCookieDurationMinutes: 20160
   });

--- a/DOL.WHD.Section14c.Web/package-lock.json
+++ b/DOL.WHD.Section14c.Web/package-lock.json
@@ -1171,6 +1171,15 @@
         "callsite": "1.0.0"
       }
     },
+    "bfj": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/bfj/-/bfj-2.1.2.tgz",
+      "integrity": "sha1-IRhBAizrcwGdp9ckJRHo0fRPrGw=",
+      "dev": true,
+      "requires": {
+        "check-types": "7.0.1"
+      }
+    },
     "big.js": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
@@ -1595,6 +1604,12 @@
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
       }
+    },
+    "check-types": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/check-types/-/check-types-7.0.1.tgz",
+      "integrity": "sha1-b77npFoqx46VdtG5DnkxGtKdJbI=",
+      "dev": true
     },
     "chokidar": {
       "version": "1.7.0",
@@ -3569,6 +3584,12 @@
       "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M=",
       "dev": true
     },
+    "freeport": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/freeport/-/freeport-1.0.5.tgz",
+      "integrity": "sha1-JV6KuEFwwzuoXZkOghrl9KGpvF0=",
+      "dev": true
+    },
     "fresh": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.3.0.tgz",
@@ -5070,6 +5091,15 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
     },
+    "hasbin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/hasbin/-/hasbin-1.2.3.tgz",
+      "integrity": "sha1-eMWSaJPIAhXCtWiuH9P8q3omlrA=",
+      "dev": true,
+      "requires": {
+        "async": "1.5.2"
+      }
+    },
     "hasha": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
@@ -5392,6 +5422,12 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
       "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA=",
+      "dev": true
+    },
+    "is": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz",
+      "integrity": "sha1-0Kwq1V63sL7JJqUmb2xmKqqD3KU=",
       "dev": true
     },
     "is-absolute": {
@@ -7223,6 +7259,15 @@
         }
       }
     },
+    "node-phantom-simple": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/node-phantom-simple/-/node-phantom-simple-2.2.4.tgz",
+      "integrity": "sha1-T8Tv+7AvJB+1CCvU+6s5jkrstk0=",
+      "dev": true,
+      "requires": {
+        "debug": "2.2.0"
+      }
+    },
     "node-sass": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz",
@@ -7290,6 +7335,15 @@
             "minimist": "0.0.8"
           }
         }
+      }
+    },
+    "node.extend": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/node.extend/-/node.extend-1.1.6.tgz",
+      "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
+      "dev": true,
+      "requires": {
+        "is": "3.2.1"
       }
     },
     "nopt": {
@@ -7628,6 +7682,44 @@
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
+      }
+    },
+    "pa11y": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/pa11y/-/pa11y-4.12.2.tgz",
+      "integrity": "sha512-X3UUWC781o8iLQ7OtdLPsAnYHyR7bTsXHwGIOyiBAMM7ENBIGka2MD9p6KejJ+QqdK5eB5sYpfT6AsdH6IRXYQ==",
+      "dev": true,
+      "requires": {
+        "async": "2.5.0",
+        "bfj": "2.1.2",
+        "chalk": "1.1.3",
+        "commander": "2.11.0",
+        "lower-case": "1.1.4",
+        "node.extend": "1.1.6",
+        "once": "1.4.0",
+        "phantomjs-prebuilt": "2.1.15",
+        "semver": "5.4.1",
+        "truffler": "3.1.0"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+          "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "once": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "dev": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        }
       }
     },
     "pako": {
@@ -10259,6 +10351,30 @@
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
       "dev": true
+    },
+    "truffler": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/truffler/-/truffler-3.1.0.tgz",
+      "integrity": "sha1-xuSG+AKx5HnVnu+VpaHtBygmT5A=",
+      "dev": true,
+      "requires": {
+        "async": "2.1.5",
+        "freeport": "1.0.5",
+        "hasbin": "1.2.3",
+        "node-phantom-simple": "2.2.4",
+        "node.extend": "1.1.6"
+      },
+      "dependencies": {
+        "async": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+          "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+          "dev": true,
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        }
+      }
     },
     "tryit": {
       "version": "1.0.3",

--- a/DOL.WHD.Section14c.Web/package.json
+++ b/DOL.WHD.Section14c.Web/package.json
@@ -9,10 +9,9 @@
     "testd": "DEBUG=true karma start",
     "start": "webpack-dev-server",
     "clean": "rimraf ./dist/*",
-    "prettier":
-      "prettier --single-quote --trailing-comma none --semi true --write \"src/**/*.js\"",
-    "deploy":
-      "npm run clean && webpack -p --config ./webpack.production.config.js && ncp index.html ./dist/index.html && ncp env.js ./dist/env.js"
+    "pa11y": "pa11y",
+    "prettier": "prettier --single-quote --trailing-comma none --semi true --write \"src/**/*.js\"",
+    "deploy": "npm run clean && webpack -p --config ./webpack.production.config.js && ncp index.html ./dist/index.html && ncp env.js ./dist/env.js"
   },
   "author": "",
   "license": "CC0-1.0",
@@ -51,6 +50,7 @@
     "ngtemplate-loader": "^1.3.1",
     "node-bourbon": "^4.2.8",
     "node-sass": "^3.10.0",
+    "pa11y": "^4.12.2",
     "prettier": "^1.6.1",
     "protractor": "~4.0.14",
     "resolve-url-loader": "^1.6.0",

--- a/DOL.WHD.Section14c.Web/src/modules/app.js
+++ b/DOL.WHD.Section14c.Web/src/modules/app.js
@@ -25,6 +25,7 @@ import ngCookies from 'angular-cookies';
 // angular 4 components (& downgrade dependencies)
 import { downgradeComponent } from '@angular/upgrade/static';
 import { HelloWorldComponent } from '../v4/hello-world.component';
+import { UiLibraryComponent } from '../v4/ui-library.component';
 
 // Styles
 import '../styles/main.scss';
@@ -43,12 +44,15 @@ let app = angular.module('14c', [
   'pagination'
 ]);
 
-app.directive(
-  'helloWorld',
-  downgradeComponent({
-    component: HelloWorldComponent
-  })
-);
+app
+  .directive(
+    'helloWorld',
+    downgradeComponent({ component: HelloWorldComponent })
+  )
+  .directive(
+    'uiLibrary',
+    downgradeComponent({ component: UiLibraryComponent })
+  );
 
 // Environment config loaded from env.js
 let env = {};
@@ -160,6 +164,7 @@ app.config(function($routeProvider, $compileProvider) {
       access: ROUTE_ADMIN
     })
     .when('/v4/hello', { template: '<hello-world></hello-world>' })
+    .when('/v4/ui-library', { template: '<ui-library></ui-library>' })
     .otherwise({
       redirectTo: '/'
     });

--- a/DOL.WHD.Section14c.Web/src/v4/app.module.ts
+++ b/DOL.WHD.Section14c.Web/src/v4/app.module.ts
@@ -3,11 +3,12 @@ import { BrowserModule } from '@angular/platform-browser';
 import { UpgradeModule } from '@angular/upgrade/static';
 
 import { HelloWorldComponent } from './hello-world.component';
+import { UiLibraryComponent } from './ui-library.component';
 
 @NgModule({
   imports: [BrowserModule, UpgradeModule],
-  declarations: [HelloWorldComponent],
-  entryComponents: [HelloWorldComponent]
+  declarations: [HelloWorldComponent, UiLibraryComponent],
+  entryComponents: [HelloWorldComponent, UiLibraryComponent]
 })
 export class AppModule {
   ngDoBootstrap() {}

--- a/DOL.WHD.Section14c.Web/src/v4/ui-library.component.css
+++ b/DOL.WHD.Section14c.Web/src/v4/ui-library.component.css
@@ -2,4 +2,10 @@
 
 .float-inherit { float: inherit !important; }
 .p0 { padding: 0 !important; }
+.m0 { margin: 0 !important; }
 .ml0 { margin-left: 0 !important; }
+.mb2 { margin-bottom: 2rem !important; }
+.mb3 { margin-bottom: 3rem !important; }
+.mb5 { margin-bottom: 5rem !important; }
+
+.mw-300p { max-width: 300px; }

--- a/DOL.WHD.Section14c.Web/src/v4/ui-library.component.css
+++ b/DOL.WHD.Section14c.Web/src/v4/ui-library.component.css
@@ -1,4 +1,8 @@
-/* misc custom styles */
+/*
+  misc custom styles needed to reset / override
+  existing ones so that UI components can nicely
+  show up on one page together
+*/
 
 .float-inherit { float: inherit !important; }
 .p0 { padding: 0 !important; }

--- a/DOL.WHD.Section14c.Web/src/v4/ui-library.component.css
+++ b/DOL.WHD.Section14c.Web/src/v4/ui-library.component.css
@@ -1,0 +1,5 @@
+/* misc custom styles */
+
+.float-inherit { float: inherit !important; }
+.p0 { padding: 0 !important; }
+.ml0 { margin-left: 0 !important; }

--- a/DOL.WHD.Section14c.Web/src/v4/ui-library.component.html
+++ b/DOL.WHD.Section14c.Web/src/v4/ui-library.component.html
@@ -1,9 +1,9 @@
-<h1>UI Library</h1>
+<h1>UI Library for 508 Testing</h1>
 
 <h2 class="mb3">Basic elements</h2>
 
 <div class="mb2">
-  <a href="#!/v4/ui-library">A lovely link</a>
+  <a href="/foo">A lovely link</a>
 </div>
 
 <div class="form-footer-controls p0">

--- a/DOL.WHD.Section14c.Web/src/v4/ui-library.component.html
+++ b/DOL.WHD.Section14c.Web/src/v4/ui-library.component.html
@@ -1,0 +1,103 @@
+<h1>UI Library</h1>
+
+<h2>Basic elements</h2>
+
+<div class="form-footer-controls p0">
+  <button type='button'>Button 1</button>
+  <button class="back-button">Button 2</button>
+  <button class="next-button ml0">Button 3</button>
+</div>
+
+<h2>Forms</h2>
+
+<div class="form-page float-inherit">
+  <div class="form-question-block">
+    <div class="form-question-text">Which bear is best?
+      <div class="help-link">?</div>
+      <div class="help-text show">
+        It’s a simple question :)
+      </div>
+    </div>
+    <fieldset class="usa-fieldset-inputs form-question-answer">
+      <ul class="usa-unstyled-list">
+        <li>
+          <input id="q1_0" type="radio" name="q1" class="ng-valid ng-not-empty ng-dirty ng-touched" value="true">
+          <label for="q1_0">Black</label>
+        </li>
+        <li>
+          <input id="q1_1" type="radio" name="q1" class="ng-valid ng-not-empty ng-dirty ng-touched ng-valid-parse" value="false">
+          <label for="q1_1">Polar</label>
+        </li>
+        <li>
+          <input id="q1_2" type="radio" name="q1" class="ng-valid ng-not-empty ng-dirty ng-touched ng-valid-parse" value="false">
+          <label for="q1_2">Panda</label>
+        </li>
+      </ul>
+    </fieldset>
+  </div>
+</div>
+
+<h2>Tables</h2>
+
+<table class="usa-table-borderless expandable-table">
+  <thead>
+    <tr>
+      <td></td>
+      <th scope="col">Column 1</th>
+      <th scope="col">Column 2</th>
+      <th scope="col"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr class="expanding-row">
+      <td>
+        <div class="arrow-expander"></div>
+      </td>
+      <th scope="row">
+        <div class="ng-binding">Foo</div>
+      </th>
+      <td class="ng-binding"></td>
+      <td>
+        <button class="green-button">Edit</button>
+        <button class="usa-button-secondary">Delete</button>
+      </td>
+    </tr>
+    <tr class="expanded-row " ng-repeat-end="">
+      <td></td>
+      <td colspan="3">
+      </td>
+    </tr>
+    <tr class="expanding-row greyed">
+      <td>
+        <div class="arrow-expander"></div>
+      </td>
+      <th scope="row">
+        <div class="ng-binding">Bar</div>
+      </th>
+      <td class="ng-binding"></td>
+      <td>
+        <button class="green-button">Edit</button>
+        <button class="usa-button-secondary">Delete</button>
+      </td>
+    </tr>
+    <tr class="expanded-row greyed" ng-repeat-end="">
+      <td></td>
+      <td colspan="3">
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>Misc</h2>
+
+<nav role="navigation" class="main-nav-bar collapsed">
+  <ul>
+    <li class="nav-button active" data-sectionid="assurances">Assurances</li>
+    <li class="nav-button" data-sectionid="app-info">Application Info</li>
+    <li class="nav-button" data-sectionid="employer">Employer</li>
+    <li class="nav-button" data-sectionid="wage-data">Wage Data</li>
+    <li class="nav-button" data-sectionid="work-sites">Work Sites & Employees</li>
+    <li class="nav-button" data-sectionid="wioa">WIOA</li>
+    <li class="nav-button ng-hide" data-sectionid="review">Review & Submit</li>
+  </ul>
+</nav>

--- a/DOL.WHD.Section14c.Web/src/v4/ui-library.component.html
+++ b/DOL.WHD.Section14c.Web/src/v4/ui-library.component.html
@@ -1,16 +1,20 @@
 <h1>UI Library</h1>
 
-<h2>Basic elements</h2>
+<h2 class="mb3">Basic elements</h2>
+
+<div class="mb2">
+  <a href="#!/v4/ui-library">A lovely link</a>
+</div>
 
 <div class="form-footer-controls p0">
-  <button type='button'>Button 1</button>
+  <button type="button">Button 1</button>
   <button class="back-button">Button 2</button>
   <button class="next-button ml0">Button 3</button>
 </div>
 
-<h2>Forms</h2>
+<h2 class="mb3">Form elements</h2>
 
-<div class="form-page float-inherit">
+<div class="form-page float-inherit m0">
   <div class="form-question-block">
     <div class="form-question-text">Which bear is best?
       <div class="help-link">?</div>
@@ -35,9 +39,58 @@
       </ul>
     </fieldset>
   </div>
+
+  <div class="form-question-block">
+    <div class="form-question-text">
+      Please attach your long-form birth certificate. Just kidding :)
+      <div class="help-link">?</div>
+      <div class="help-text"></div>
+    </div>
+    <div>
+      <input id="99_FileUpload" class="upload-file-input ng-hide" type="file" ng-hide="true" accept=".doc,.docx,.xls,.xlsx,.pdf,.jpg,.jpeg,.png">
+      <label for="99_FileUpload" class="upload-label usa-button-primary">Browse</label>
+      <input id="99" name="99" class="upload-input" type="text" disabled="">
+      <label class="underlabel" for="99">File types accepted: PDF, Word, Excel, JPG, PNG</label>
+    </div>
+  </div>
+
+  <div class="form-question-block">
+    <fieldset class="usa-fieldset-inputs form-question-answer">
+      <ul class="usa-unstyled-list">
+        <li>
+          <input id="agreement" type="checkbox" name="agreement" class="ng-valid ng-dirty ng-valid-parse ng-not-empty ng-touched" value="true">
+          <label for="agreement" class="full-width-label">I agree to check this box.</label>
+        </li>
+      </ul>
+    </fieldset>
+  </div>
+
+  <div class="form-question-block">
+    <div class="form-question-answer">
+      <label for="contactName">Full Name</label>
+      <input id="contactName" name="contactName" type="text" class="ng-pristine ng-untouched ng-valid ng-empty">
+    </div>
+  </div>
+
+  <div class="form-question-block">
+    <div class="form-question-answer">
+      <label for="contactEmail">Email Address</label>
+      <input id="contactEmail" name="contactEmail" type="email" class="sidelabeled email ng-pristine ng-untouched ng-valid ng-empty ng-valid-email">
+      <label class="example">Example: contact.name@company.com</label>
+    </div>
+  </div>
+
+  <div class="form-question-block usa-input-error">
+    <div class="form-question-answer">
+      <label for="contactPhone">Telephone Number</label>
+      <span class="usa-input-error-message ng-binding" role="alert">Please provide a valid contact telephone number</span>
+      <input id="contactPhone" name="contactPhone" type="tel" mask="999-999-9999" class="sidelabeled phoneno ng-pristine ng-untouched ng-valid ng-empty">
+      <label class="example">Example: 123-456-7890</label>
+    </div>
+  </div>
 </div>
 
-<h2>Tables</h2>
+<h2 class="mb3">Tables</h2>
 
 <table class="usa-table-borderless expandable-table">
   <thead>
@@ -58,8 +111,8 @@
       </th>
       <td class="ng-binding"></td>
       <td>
-        <button class="green-button">Edit</button>
-        <button class="usa-button-secondary">Delete</button>
+        <button class="green-button">A</button>
+        <button class="usa-button-secondary">B</button>
       </td>
     </tr>
     <tr class="expanded-row " ng-repeat-end="">
@@ -76,8 +129,8 @@
       </th>
       <td class="ng-binding"></td>
       <td>
-        <button class="green-button">Edit</button>
-        <button class="usa-button-secondary">Delete</button>
+        <button class="green-button">A</button>
+        <button class="usa-button-secondary">B</button>
       </td>
     </tr>
     <tr class="expanded-row greyed" ng-repeat-end="">
@@ -88,16 +141,94 @@
   </tbody>
 </table>
 
-<h2>Misc</h2>
+<h2 class="mb3">Misc</h2>
 
-<nav role="navigation" class="main-nav-bar collapsed">
-  <ul>
-    <li class="nav-button active" data-sectionid="assurances">Assurances</li>
-    <li class="nav-button" data-sectionid="app-info">Application Info</li>
-    <li class="nav-button" data-sectionid="employer">Employer</li>
-    <li class="nav-button" data-sectionid="wage-data">Wage Data</li>
-    <li class="nav-button" data-sectionid="work-sites">Work Sites & Employees</li>
-    <li class="nav-button" data-sectionid="wioa">WIOA</li>
-    <li class="nav-button ng-hide" data-sectionid="review">Review & Submit</li>
-  </ul>
-</nav>
+<div class="mb5">
+  <nav role="navigation" class="main-nav-bar collapsed">
+    <ul>
+      <li class="nav-button active" data-sectionid="assurances">Assurances</li>
+      <li class="nav-button" data-sectionid="app-info">Application Info</li>
+      <li class="nav-button" data-sectionid="employer">Employer</li>
+      <li class="nav-button" data-sectionid="wage-data">Wage Data</li>
+      <li class="nav-button" data-sectionid="work-sites">Work Sites & Employees</li>
+      <li class="nav-button" data-sectionid="wioa">WIOA</li>
+      <li class="nav-button ng-hide" data-sectionid="review">Review & Submit</li>
+    </ul>
+  </nav>
+</div>
+
+<div class="mb5">
+  <div id="wagedata_tab_box" class="form-tabbed-section">
+    <div class="form-tab active">
+      <div class="circle">1</div> Hourly
+    </div>
+    <div class="form-tab ">
+      <div class="circle">2</div> Piece Rate
+    </div>
+  </div>
+</div>
+
+<div class="mb5">
+  <div class="dol-applicant-meta">
+    <div class="dol-feedback-save">
+      <span class="dol-feedback-save-success ng-binding">
+        Saved 09/11/2017, 11:53 AM
+      </span>
+    </div>
+    <div class="dol-applicant-ein">
+      Applicant EIN:
+      <span class="ng-binding">12-1233333</span>
+    </div>
+  </div>
+  <div class="dol-form-meta">
+    <div class="usa-content">
+      <p>Application for Authority to Employ Workers with Disabilities at Subminimum Wages</p>
+      <p class="ng-hide">Applicant EIN:
+        <span class="ng-binding">XX-XXXXXXX</span>
+      </p>
+    </div>
+    <div class="dol-form-omb" ng-show="!admin">
+      <p>OMB NO: 1235-0001</p>
+      <p>REV XX/20XX</p>
+    </div>
+  </div>
+</div>
+
+<div class="mb5">
+  <div class="main-content form-content">
+    <div class="usa-alert usa-alert-error" role="alert">
+      <div class="usa-alert-body">
+        <p class="usa-alert-text">Please review this page. There are errors or missing information that we need to collect before you can submit the form.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="mb5">
+  <div class="reviewbar">
+    <div class="reviewbar-container">
+      <div class="reviewbar-bar"></div>
+      <div class="reviewbar-circle"></div>
+    </div>
+  </div>
+  <div class="reviewbar error">
+    <div class="reviewbar-container">
+      <div class="reviewbar-bar"></div>
+      <div class="reviewbar-circle"></div>
+    </div>
+  </div>
+</div>
+
+<div class="mb5">
+  <div class="dol-panel-login">
+    <h2>Log in</h2>
+    <p>...</p>
+  </div>
+</div>
+
+<div class="mb5">
+  <div class="dol-panel-info mw-300p">
+    <h3>Questions?</h3>
+    <p>Contact the <a href="#">Wage and Hour office closest to you.</a></p>
+  </div>
+</div>

--- a/DOL.WHD.Section14c.Web/src/v4/ui-library.component.ts
+++ b/DOL.WHD.Section14c.Web/src/v4/ui-library.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'ui-library',
+  templateUrl: 'src/v4/ui-library.component.html',
+  styleUrls: ['src/v4/ui-library.component.css']
+})
+export class UiLibraryComponent {}


### PR DESCRIPTION
This PR starts to address https://github.com/18F/dol-whd-14c/issues/211

There's now a new page (at `/v4/ui-library`) with a compilation of the major UI components used throughout the app. In addition, I added `pa11y`, an automated accessibility testing tool, so that we can check URLs and HTML files for accessibility rules / requirements.

For example, the HTML file for this new UI library page can be scanned with `pa11y` via the command: `npm run pa11y file:///absolute/path/for/dol-whd-14c/DOL.WHD.Section14c.Web/src/v4/ui-library.component.html`

In a future PR, I will fix the infractions from the pa11y scan of this new page and highlight changes that need to be promulgated throughout the app. 

preview of new page:
![ui](https://user-images.githubusercontent.com/1060893/30296312-bd4d4bea-9711-11e7-8e53-77860c75dde0.png)
