### PR TITLE
Angular 1 to 4 upgrade example

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/components/mainTopNavControl/mainTopNav.component.ts
+++ b/DOL.WHD.Section14c.Web/src/modules/components/mainTopNavControl/mainTopNav.component.ts
@@ -1,0 +1,19 @@
+import { Directive, ElementRef, Injector } from '@angular/core';
+import { UpgradeComponent } from '@angular/upgrade/static';
+
+export const mainTopNav = {
+  restrict: 'EA',
+  template: require('./mainTopNavControlTemplate.html'),
+  controller: 'mainTopNavControlController',
+  scope: { admin: '=' },
+  controllerAs: 'vm'
+};
+
+@Directive({
+  selector: 'main-top-nav'
+})
+export class mainTopNavDirective extends UpgradeComponent {
+  constructor(elementRef: ElementRef, injector: Injector) {
+    super('mainTopNavControl', elementRef, injector);
+  }
+}

--- a/DOL.WHD.Section14c.Web/src/modules/components/mainTopNavControl/mainTopNav.component.ts
+++ b/DOL.WHD.Section14c.Web/src/modules/components/mainTopNavControl/mainTopNav.component.ts
@@ -1,14 +1,6 @@
 import { Directive, ElementRef, Injector } from '@angular/core';
 import { UpgradeComponent } from '@angular/upgrade/static';
 
-export const mainTopNav = {
-  restrict: 'EA',
-  template: require('./mainTopNavControlTemplate.html'),
-  controller: 'mainTopNavControlController',
-  scope: { admin: '=' },
-  controllerAs: 'vm'
-};
-
 @Directive({
   selector: 'main-top-nav'
 })

--- a/DOL.WHD.Section14c.Web/src/modules/components/mainTopNavControl/mainTopNavControlDirective.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/mainTopNavControl/mainTopNavControlDirective.js
@@ -1,4 +1,10 @@
-import { mainTopNav } from './mainTopNav.component';
+const mainTopNav = {
+  restrict: 'EA',
+  template: require('./mainTopNavControlTemplate.html'),
+  controller: 'mainTopNavControlController',
+  scope: { admin: '=' },
+  controllerAs: 'vm'
+};
 
 module.exports = function(ngModule) {
   ngModule.component('mainTopNavControl', mainTopNav);

--- a/DOL.WHD.Section14c.Web/src/modules/components/mainTopNavControl/mainTopNavControlDirective.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/mainTopNavControl/mainTopNavControlDirective.js
@@ -1,17 +1,5 @@
-'use strict';
+import { mainTopNav } from './mainTopNav.component';
 
 module.exports = function(ngModule) {
-  ngModule.directive('mainTopNavControl', function() {
-    'use strict';
-
-    return {
-      restrict: 'EA',
-      template: require('./mainTopNavControlTemplate.html'),
-      controller: 'mainTopNavControlController',
-      scope: {
-        admin: '='
-      },
-      controllerAs: 'vm'
-    };
-  });
+  ngModule.component('mainTopNavControl', mainTopNav);
 };

--- a/DOL.WHD.Section14c.Web/src/v4/app.module.ts
+++ b/DOL.WHD.Section14c.Web/src/v4/app.module.ts
@@ -3,10 +3,11 @@ import { BrowserModule } from '@angular/platform-browser';
 import { UpgradeModule } from '@angular/upgrade/static';
 
 import { HelloWorldComponent } from './hello-world.component';
+import { mainTopNavDirective } from '../modules/components/mainTopNavControl/mainTopNav.component';
 
 @NgModule({
   imports: [BrowserModule, UpgradeModule],
-  declarations: [HelloWorldComponent],
+  declarations: [HelloWorldComponent, mainTopNavDirective],
   entryComponents: [HelloWorldComponent]
 })
 export class AppModule {

--- a/DOL.WHD.Section14c.Web/src/v4/app.module.ts
+++ b/DOL.WHD.Section14c.Web/src/v4/app.module.ts
@@ -8,7 +8,7 @@ import { mainTopNavDirective } from '../modules/components/mainTopNavControl/mai
 @NgModule({
   imports: [BrowserModule, UpgradeModule],
   declarations: [HelloWorldComponent, UiLibraryComponent, mainTopNavDirective],
-  entryComponents: [HelloWorldComponent]
+  entryComponents: [HelloWorldComponent, UiLibraryComponent]
 })
 export class AppModule {
   ngDoBootstrap() {}

--- a/DOL.WHD.Section14c.Web/src/v4/hello-world.component.ts
+++ b/DOL.WHD.Section14c.Web/src/v4/hello-world.component.ts
@@ -5,6 +5,10 @@ import { Component } from '@angular/core';
   template: `
     <h1>Hello, World!</h1>
     <p>This is an Angular 4 component :)</p>
+    <p>This next thing is an upgraded v1 component:</p>
+    <div style="background-color:#eee; padding:0 1rem;">
+      <main-top-nav></main-top-nav>
+    </div>
   `
 })
 export class HelloWorldComponent {}


### PR DESCRIPTION
this PR addresses (c1) of https://github.com/18F/dol-whd-14c/issues/226

(c2) has already been addressed in an earlier PR (https://github.com/18F/dol-whd-14c/pull/232)

This demonstrates how one can upgrade an AngularJS component to be used inside Angular. To do this, I follow [this](https://angular.io/guide/upgrade#using-angularjs-component-directives-from-angular-code) guide (migrating first to the component API introduced in AngularJS 1.5 and then extending the `UpgradeComponent` introduced in Angular).

preview of the v1 component (the top navigation bar) in a v4 component:
<img width="1230" alt="screen shot 2017-09-12 at 1 02 01 pm" src="https://user-images.githubusercontent.com/1060893/30339385-db015234-97bc-11e7-9d83-8b04f84480fd.png">
