### PR TITLE
add pa11y scan script (with auth)

### DIFF
--- a/DOL.WHD.Section14c.Web/pa11yScan.js
+++ b/DOL.WHD.Section14c.Web/pa11yScan.js
@@ -6,6 +6,7 @@
 // -p 'password123' \
 // -u 'https://dol-whd-section14c-stg.azurewebsites.net/#/section/work-sites'
 
+const _ = require('lodash');
 const pa11y = require('pa11y');
 const program = require('commander');
 
@@ -57,13 +58,15 @@ const runner = pa11y({
     // redirect related methods
 
     function doRedirect(args) {
-      document.location = args.url;
-      document.location.reload();
+      window.location = args.url;
+      window.location.reload();
     }
 
     function checkRedirect(args) {
       // check that current url = target url
-      return window.location.href === args.url;
+      const currUrl = window.location.href;
+      console.log('Current url:', currUrl);
+      return currUrl === args.url;
     }
 
     function startPa11y() {
@@ -116,10 +119,25 @@ const runner = pa11y({
   }
 });
 
+function prettyEntry(e) {
+  return `${e.code}\n\n${e.message}\n\n${e.context}\n\n---\n`;
+}
+
+function handleResults(data) {
+  console.log('\n\nPa11y results:\n------\n');
+  const dataGrouped = _.groupBy(data, d => d.type);
+
+  for (const key in dataGrouped) {
+    const entries = dataGrouped[key];
+    console.log(`"${key}" entries: ${entries.length}`);
+  }
+
+  console.log('\n\nHere are the error entries:\n------\n');
+  const errors = dataGrouped.error || [];
+  errors.forEach(e => console.log(prettyEntry(e)));
+}
+
 runner.run(PARAMS.url, (error, results) => {
   if (error) return console.error(error.message);
-
-  console.log(results);
-  console.log();
-  console.log(`number of pa11y results: ${results.length}`);
+  handleResults(results);
 });

--- a/DOL.WHD.Section14c.Web/pa11yScan.js
+++ b/DOL.WHD.Section14c.Web/pa11yScan.js
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+
+// example command:
+// ./pa11yScan.js \
+// -e 'somebody@gmail.com' \
+// -p 'password123' \
+// -u 'https://dol-whd-section14c-stg.azurewebsites.net/#/section/work-sites'
+
+const pa11y = require('pa11y');
+const program = require('commander');
+
+program
+  .description('Run an accessibility test against a 14(c) app URL')
+  .option('-e, --email <email>', 'Add user email')
+  .option('-p, --password <password>', 'Add user password')
+  .option('-u, --url <url>', 'Add URL to scan')
+  .parse(process.argv);
+
+const errMsg = `
+  Uh-oh! Make sure you specify the proper params.
+  For help, run: ./pa11yScan.js --help
+`;
+
+if (!program.email || !program.password || !program.url) {
+  console.error(errMsg);
+  process.exit(1);
+}
+
+const PARAMS = {
+  userVal: program.email,
+  pwVal: program.password,
+  url: program.url
+};
+
+const runner = pa11y({
+  log: {
+    debug: console.log.bind(console),
+    error: console.error.bind(console),
+    info: console.log.bind(console)
+  },
+
+  beforeScript: function(page, options, next) {
+    // show console messages from web page
+    page.onConsoleMessage = msg => console.log(msg);
+
+    // check for some condition on web page before continuing
+    function waitUntil(condition, retries, waitOver) {
+      page.evaluate(condition, PARAMS, (error, result) => {
+        if (result || retries < 1) waitOver();
+        else {
+          retries -= 1;
+          setTimeout(() => waitUntil(condition, retries, waitOver), 200);
+        }
+      });
+    }
+
+    // redirect to proper (authenticated) page, then start pa11y
+    function pageRedirect() {
+      console.log('Redirecting to proper url...');
+
+      page.evaluate(
+        function(args) {
+          document.location = args.url;
+          document.location.reload();
+        },
+        PARAMS,
+        function() {
+          waitUntil(
+            function(args) {
+              return window.location.href === args.url; // current = target
+            },
+            10,
+            function() {
+              setTimeout(next, 1000);
+            }
+          );
+        }
+      );
+    }
+
+    // user input shouldn't be on page if login successful
+    function authCheck() {
+      return document.querySelector('#userName') === null;
+    }
+
+    function postAuth() {
+      waitUntil(authCheck, 10, pageRedirect);
+    }
+
+    function doAuth(args) {
+      console.log('args:', JSON.stringify(args));
+      console.log('Filling in login form...');
+
+      var user = document.querySelector('#userName');
+      var password = document.querySelector('#password');
+      var submit = document.querySelector('.loginbtn button');
+
+      var userEl = angular.element(user);
+      var pwEl = angular.element(password);
+
+      userEl.val(args.userVal);
+      userEl.triggerHandler('input');
+
+      pwEl.val(args.pwVal);
+      pwEl.triggerHandler('input');
+
+      console.log('Submitting login form...');
+      submit.click();
+    }
+
+    // 1. log in
+    // 2. check that auth was successful
+    // 3. do post auth stuff
+    page.evaluate(doAuth, PARAMS, postAuth);
+  }
+});
+
+runner.run(PARAMS.url, (error, results) => {
+  if (error) return console.error(error.message);
+
+  console.log(results);
+  console.log();
+  console.log(`number of pa11y results: ${results.length}`);
+});

--- a/DOL.WHD.Section14c.Web/pa11yScan.js
+++ b/DOL.WHD.Section14c.Web/pa11yScan.js
@@ -54,38 +54,32 @@ const runner = pa11y({
       });
     }
 
-    // redirect to proper (authenticated) page, then start pa11y
+    // redirect related methods
+
+    function doRedirect(args) {
+      document.location = args.url;
+      document.location.reload();
+    }
+
+    function checkRedirect(args) {
+      // check that current url = target url
+      return window.location.href === args.url;
+    }
+
+    function startPa11y() {
+      setTimeout(next, 1000);
+    }
+
+    function postRedirect() {
+      waitUntil(checkRedirect, 10, startPa11y);
+    }
+
     function pageRedirect() {
       console.log('Redirecting to proper url...');
-
-      page.evaluate(
-        function(args) {
-          document.location = args.url;
-          document.location.reload();
-        },
-        PARAMS,
-        function() {
-          waitUntil(
-            function(args) {
-              return window.location.href === args.url; // current = target
-            },
-            10,
-            function() {
-              setTimeout(next, 1000);
-            }
-          );
-        }
-      );
+      page.evaluate(doRedirect, PARAMS, postRedirect);
     }
 
-    // user input shouldn't be on page if login successful
-    function authCheck() {
-      return document.querySelector('#userName') === null;
-    }
-
-    function postAuth() {
-      waitUntil(authCheck, 10, pageRedirect);
-    }
+    // auth related methods
 
     function doAuth(args) {
       console.log('args:', JSON.stringify(args));
@@ -108,9 +102,16 @@ const runner = pa11y({
       submit.click();
     }
 
-    // 1. log in
-    // 2. check that auth was successful
-    // 3. do post auth stuff
+    function checkAuth() {
+      // user input shouldn't be on page if login successful
+      return document.querySelector('#userName') === null;
+    }
+
+    function postAuth() {
+      waitUntil(checkAuth, 10, pageRedirect);
+    }
+
+    // kick things off (log in -> go to proper page)
     page.evaluate(doAuth, PARAMS, postAuth);
   }
 });

--- a/DOL.WHD.Section14c.Web/package.json
+++ b/DOL.WHD.Section14c.Web/package.json
@@ -25,6 +25,7 @@
     "babel-polyfill": "^6.16.0",
     "babel-preset-es2015": "^6.14.0",
     "canonical-path": "0.0.2",
+    "commander": "^2.11.0",
     "concurrently": "^3.2.0",
     "copy-webpack-plugin": "^3.0.1",
     "css-loader": "^0.25.0",


### PR DESCRIPTION
This PR adds a script that runs an accessibility test against an authenticated page within the 14(c) app. 

Before scanning the page, it attempts to log in via the supplied username/password parameters. This login mechanism is fairly brittle (it targets form elements via their #id / CSS class), so this script may need to be changed/updated if and when the login form UI changes. 

example command:

```
./pa11yScan.js \
-e 'somebody@gmail.com' \
-p 'password123' \
-u 'https://dol-whd-section14c-stg.azurewebsites.net/#/section/work-sites'
```

Right now, the output simply displays all of the pa11y issues/results; in time, we can filter this list / store it in a nicer format for post-processing / analysis.