### PR TITLE
Update pa11y script to inject env

### DIFF
--- a/DOL.WHD.Section14c.Web/pa11yScan.js
+++ b/DOL.WHD.Section14c.Web/pa11yScan.js
@@ -21,6 +21,7 @@
 
 */
 
+const fs = require('fs');
 const _ = require('lodash');
 const pa11y = require('pa11y');
 const program = require('commander');
@@ -143,8 +144,23 @@ const runner = pa11y({
       waitUntil(checkAuth, 10, pageRedirect);
     }
 
+    function setEnvGlobal(envFnStr) {
+      // Loads env into window.__env
+      eval(envFnStr); // eslint-disable-line no-eval
+
+      // The _env global is an object, so while we can't change
+      // the reference, we CAN change its properties.
+      var globalEnvObject = angular.element(document.body).injector().get('_env');
+      Object.assign(globalEnvObject, window.__env);
+    }
+
+    function setEnv(callback) {
+      const envFnStr = fs.readFileSync('env.js', { encoding: 'utf-8' });
+      page.evaluate(setEnvGlobal, envFnStr, callback);
+    }
+
     // kick things off (log in -> go to proper page)
-    page.evaluate(doAuth, PARAMS, postAuth);
+    setEnv(() => page.evaluate(doAuth, PARAMS, postAuth));
   }
 });
 


### PR DESCRIPTION
Deals with some kind of quirk with phantomjs by injecting env into the angular global.  For some reason, the `env.js` file doesn't seem to execute correctly (or else it doesn't share a global `window` with the rest of the app).  So...

1. Load the `env.js` file from source
2. `eval()` the source in the context of the page
3. update the `_env` angular global

@brendansudol You should be able to merge this one if you want, since it isn't into `master`.