### PR TITLE
[WIP] accessible help-text

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/components/formSection/formSectionDirective.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/formSection/formSectionDirective.js
@@ -16,7 +16,7 @@ module.exports = function(ngModule) {
     'use strict';
 
     return {
-      template: '<div class="help-link">?</div>',
+      template: '<button type="button" class="help-link">?</button>',
       replace: true,
       link: function(scope, element, attrs) {
         element.bind('click', function() {

--- a/DOL.WHD.Section14c.Web/src/styles/forms.scss
+++ b/DOL.WHD.Section14c.Web/src/styles/forms.scss
@@ -179,8 +179,9 @@ span.example {
             display: inline-block;
             width: 20px;
             height: 20px;
-            vertical-align: -1px;
-            margin-left: 7px;
+            vertical-align: 2px;
+            margin: 0 0 0 4px;
+            padding: 0;
             cursor: pointer;
             background: url('../images/dol-help-blue.png') center center;
             background: url('../images/dol-help-blue.svg') center center;


### PR DESCRIPTION
This PR addresses https://github.com/18F/dol-whd-14c/issues/248

It makes the help-text icons keyboard accessible (via tabbing and return/space to toggle). The icon (and help text content) is already visually accessible in terms of color contrast. 

preview:
![q-help](https://user-images.githubusercontent.com/1060893/30872558-7af4d986-a2b8-11e7-86f1-adfee1f71d43.gif)