### PR TITLE
add aria-describedbys for help text

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/components/formSection/formSectionDirective.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/formSection/formSectionDirective.js
@@ -31,7 +31,11 @@ module.exports = function(ngModule) {
 
     return {
       transclude: true,
-      template: '<div class="help-text"><ng-transclude></ng-transclude></div>',
+      template: `
+        <div id="{{ id }}" class="help-text">
+          <ng-transclude></ng-transclude>
+        </div>
+      `,
       replace: true,
       link: function(scope, element, attrs) {
         scope.$watch('showAllHelp', function() {

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionAppInfo/sectionAppInfoTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionAppInfo/sectionAppInfoTemplate.html
@@ -18,7 +18,7 @@
   <div class="form-question-block" ng-class="validate('applicationTypeId') ? 'usa-input-error' : ''">
     <div class="form-question-text">What type of application is this?
       <helplink></helplink>
-      <helptext>Initial applicants are those who do not currently hold a valid section 14 (c) certificate. Renewal applicants are employers who currently hold a valid certificate.</helptext>
+      <helptext id="applicationTypeIdHelp">Initial applicants are those who do not currently hold a valid section 14 (c) certificate. Renewal applicants are employers who currently hold a valid certificate.</helptext>
     </div>
     <div class="form-question-subtext">If the employer currently holds a valid 14(c) certificate, choose Renewal. If not, choose Initial.</div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('applicationTypeId')">{{ validate('applicationTypeId') }}</span>
@@ -26,7 +26,7 @@
       <legend class="hide">Application type</legend>
       <ul class="usa-unstyled-list">
         <li ng-repeat="response in responses.ApplicationType">
-          <input id="applicationType_{{ response.id }}" type="radio" name="applicationTypeId" ng-value="response.id" ng-model="formData.applicationTypeId">
+          <input id="applicationType_{{ response.id }}" type="radio" name="applicationTypeId" aria-describedby="applicationTypeIdHelp" ng-value="response.id" ng-model="formData.applicationTypeId">
           <label for="applicationType_{{ response.id }}">{{ response.display }}</label>
         </li>
       </ul>
@@ -81,7 +81,7 @@
   <div class="form-question-block" ng-class="validate('establishmentTypeId') ? 'usa-input-error' : ''">
     <div class="form-question-text">What type of establishment(s) is this request for authority to employ workers with disabilities for?
       <helplink></helplink>
-      <helptext>
+      <helptext id="establishmentTypeIdHelp">
         <p><strong>Community Rehabilitation (Work Center):</strong> facility that primarily provides vocational rehabilitation services and employment for people with disabilities.</p>
         <p><strong>Hospital/Residential Care Facility (Patient Workers):</strong> A facility (public or private, non-profit or for-profit) that primarily providesresidential care for individuals with disabilities, including but not limited to nursing homes, intermediate care facilities, assistedliving facilities, halfway houses, and residential substance abuse treatment facilities. “Primarily” means that more than 50 percentof the facility’s income is attributable to this residential care.A patient worker is a worker with a disability who is employed by a hospital or residential care facility (as defined above) where thepatient worker receives inpatient or outpatient treatment or care.</p>
         <p><strong>School Work Experience Program (SWEP):</strong> A school-operated program in which students with disabilities may be placed in jobswith private industry within the community. School employers are responsible for compliance with all applicable child labor laws,minimum wage standards, and certificate and recordkeeping requirements. The school may submit a group application whichcovers all students with disabilities and all of the business locations at which the students will be placed.</p>
@@ -94,7 +94,7 @@
       <legend class="hide">Establishment type ID</legend>
       <ul class="usa-unstyled-list">
         <li ng-repeat="response in responses.EstablishmentType">
-          <input id="establishmentType_{{ response.id }}" type="checkbox" name="establishmentTypeId" ng-value="response.id" ng-checked="formData.establishmentTypeId.indexOf(response.id) > -1" ng-click="vm.toggleEstablishmentType(response.id)">
+          <input id="establishmentType_{{ response.id }}" type="checkbox" name="establishmentTypeId" aria-describedby="establishmentTypeIdHelp" ng-value="response.id" ng-checked="formData.establishmentTypeId.indexOf(response.id) > -1" ng-click="vm.toggleEstablishmentType(response.id)">
           <label for="establishmentType_{{ response.id }}">{{ response.display }}</label>
           <div class="underlabel checkbox-indent">{{ response.subDisplay }}</div>
         </li>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionEmployer/sectionEmployerTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionEmployer/sectionEmployerTemplate.html
@@ -20,25 +20,25 @@
   <div class="form-question-block" ng-class="validate('employer.legalName') ? 'usa-input-error' : ''">
     <div class="form-question-text">Legal Name of Employer
       <helplink></helplink>
-      <helptext>Provide the full legal and trade name(s) of the employer, and previous name, if applicable. SWEPs should enter the identifying information for the school that is applying for the certificate.</helptext>
+      <helptext id="legalNameHelp">Provide the full legal and trade name(s) of the employer, and previous name, if applicable. SWEPs should enter the identifying information for the school that is applying for the certificate.</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('employer.legalName')">{{ validate('employer.legalName') }}</span>
     <div class="form-question-answer">
       <label for="legalName" class="hide">Legal name of employer</label>
-      <input id="legalName" name="legalName" type="text" ng-model="formData.employer.legalName">
+      <input id="legalName" name="legalName" aria-describedby="legalNameHelp" type="text" ng-model="formData.employer.legalName">
     </div>
   </div>
   <div class="form-question-block" ng-class="validate('employer.hasTradeName') ? 'usa-input-error' : ''">
     <div class="form-question-text">Does the Employer have a Trade Name?
       <helplink></helplink>
-      <helptext>Provide the full legal and trade name(s) of the employer, and previous name, if applicable. SWEPs should enter the identifying information for the school that is applying for the certificate.</helptext>
+      <helptext id="hasTradeNameHelp">Provide the full legal and trade name(s) of the employer, and previous name, if applicable. SWEPs should enter the identifying information for the school that is applying for the certificate.</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('employer.hasTradeName')">{{ validate('employer.hasTradeName') }}</span>
     <fieldset class="usa-fieldset-inputs form-question-answer">
       <legend class="hide">Has trade name?</legend>
       <ul class="usa-unstyled-list">
         <li>
-          <input id="hasTradeName_1" type="radio" name="hasTradeName" ng-value="true" ng-model="formData.employer.hasTradeName">
+          <input id="hasTradeName_1" type="radio" name="hasTradeName" aria-describedby="hasTradeNameHelp" ng-value="true" ng-model="formData.employer.hasTradeName">
           <label for="hasTradeName_1">Yes</label>
         </li>
         <li>
@@ -168,18 +168,18 @@
   <div class="form-question-block" ng-class="validate('employer.hasParentOrg') ? 'usa-input-error' : ''">
     <div class="form-question-text">Does the Employer have a Parent Organization?
       <helplink></helplink>
-      <helptext>SWEPs should enter the school district’s information in Item 4.</helptext>
+      <helptext id="hasParentOrgHelp">SWEPs should enter the school district’s information in Item 4.</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('employer.hasParentOrg')">{{ validate('employer.hasParentOrg') }}</span>
     <fieldset class="usa-fieldset-inputs form-question-answer">
       <legend class="hide">Has parent organization?</legend>
       <ul class="usa-unstyled-list">
         <li>
-          <input id="hasParentOrg_1" type="radio" name="hasParentOrg" ng-value="true" ng-model="formData.employer.hasParentOrg">
+          <input id="hasParentOrg_1" type="radio" name="hasParentOrg" aria-describedby="hasParentOrgHelp" ng-value="true" ng-model="formData.employer.hasParentOrg">
           <label for="hasParentOrg_1">Yes</label>
         </li>
         <li>
-          <input id="hasParentOrg_0" type="radio" name="hasParentOrg" ng-value="false" ng-model="formData.employer.hasParentOrg">
+          <input id="hasParentOrg_0" type="radio" name="hasParentOrg" aria-describedby="hasParentOrgHelp" ng-value="false" ng-model="formData.employer.hasParentOrg">
           <label for="hasParentOrg_0">No</label>
         </li>
       </ul>
@@ -240,14 +240,14 @@
   <div class="form-question-block" ng-class="validate(['employer.employerStatusId', 'employer.employerStatusOther']) ? 'usa-input-error' : ''">
     <div class="form-question-text">Employer Status
       <helplink></helplink>
-      <helptext>Select the option that describes the employer’s status. For example, a SWEP operated by a public school system should select “Public.”</helptext>
+      <helptext id="employerStatusHelp">Select the option that describes the employer’s status. For example, a SWEP operated by a public school system should select “Public.”</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('employer.employerStatusId')">{{ validate('employer.employerStatusId') }}</span>
     <fieldset class="usa-fieldset-inputs form-question-answer">
       <legend class="hide">Employer status</legend>
       <ul class="usa-unstyled-list">
         <li ng-repeat="response in responses.EmployerStatus">
-          <input id="paytype_{{ response.id }}" type="radio" name="employerStatus" ng-value="response.id" ng-model="formData.employer.employerStatusId">
+          <input id="paytype_{{ response.id }}" type="radio" name="employerStatus" aria-describedby="employerStatusHelp" ng-value="response.id" ng-model="formData.employer.employerStatusId">
           <label for="paytype_{{ response.id }}">{{ response.display }}</label>
         </li>
       </ul>
@@ -259,18 +259,18 @@
   <div class="form-question-block" ng-class="validate('employer.isEducationalAgency') ? 'usa-input-error' : ''">
     <div class="form-question-text">Is this employer a local or State educational agency?
       <helplink></helplink>
-      <helptext>The term “local educational agency” means a public board of education or other public authority legally constituted within a State for either administrative control or direction of, or to perform a service function for, public elementary schools or secondary schools in a city, county, township, school district, or other political subdivision of a State, or of or for a combination of school districts or counties that is recognized in a State as an administrative agency for its public elementary schools or secondary schools. The term “State educational agency” means the agency primarily responsible for the State supervision of public elementary schoolsand secondary schools. See 20 U.S.C. 7801, the Elementary and Secondary Education Act of 1965.</helptext>
+      <helptext id="isEducationalAgencyHelp">The term “local educational agency” means a public board of education or other public authority legally constituted within a State for either administrative control or direction of, or to perform a service function for, public elementary schools or secondary schools in a city, county, township, school district, or other political subdivision of a State, or of or for a combination of school districts or counties that is recognized in a State as an administrative agency for its public elementary schools or secondary schools. The term “State educational agency” means the agency primarily responsible for the State supervision of public elementary schoolsand secondary schools. See 20 U.S.C. 7801, the Elementary and Secondary Education Act of 1965.</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('employer.isEducationalAgency')">{{ validate('employer.isEducationalAgency') }}</span>
     <fieldset class="usa-fieldset-inputs form-question-answer">
       <legend class="hide">Is educational agency?</legend>
       <ul class="usa-unstyled-list">
         <li>
-          <input id="isEducationalAgency_1" type="radio" name="isEducationalAgency" ng-value="true" ng-model="formData.employer.isEducationalAgency">
+          <input id="isEducationalAgency_1" type="radio" name="isEducationalAgency" aria-describedby="isEducationalAgencyHelp" ng-value="true" ng-model="formData.employer.isEducationalAgency">
           <label for="isEducationalAgency_1">Yes</label>
         </li>
         <li>
-          <input id="isEducationalAgency_0" type="radio" name="isEducationalAgency" ng-value="false" ng-model="formData.employer.isEducationalAgency">
+          <input id="isEducationalAgency_0" type="radio" name="isEducationalAgency" aria-describedby="isEducationalAgencyHelp" ng-value="false" ng-model="formData.employer.isEducationalAgency">
           <label for="isEducationalAgency_0">No</label>
         </li>
       </ul>
@@ -282,7 +282,7 @@
     <div class="form-question-block" ng-class="validate('employer.fiscalQuarterEndDate') ? 'usa-input-error' : ''">
       <div class="form-question-text">When did the Employer’s most recently completed fiscal quarter end?
         <helplink></helplink>
-        <helptext>Provide the ending date of the employer’s most recently completed three-month fiscal quarter. For example, if the fiscal year begins on January 1, provide the date of the most recently completed quarter (March 31, June 30, September 30, or December 31).</helptext>
+        <helptext id="fiscalQuarterEndDateHelp">Provide the ending date of the employer’s most recently completed three-month fiscal quarter. For example, if the fiscal year begins on January 1, provide the date of the most recently completed quarter (March 31, June 30, September 30, or December 31).</helptext>
       </div>
       <span class="usa-input-error-message" role="alert" ng-show="validate('employer.fiscalQuarterEndDate')">{{ validate('employer.fiscalQuarterEndDate') }}</span>
       <fieldset>
@@ -294,23 +294,23 @@
     <div class="form-question-block" ng-class="validate('employer.numSubminimalWageWorkers.total') ? 'usa-input-error' : ''">
       <div class="form-question-text">What is the total number of workers with disabilities employed at subminimum wages during the most recently completed fiscal quarter at all establishments and work sites?
         <helplink></helplink>
-        <helptext>Provide the total number of workers with disabilities who were paid subminimum wages at all establishments and work sites during the most recently completed fiscal quarter. Include workers who were employed for less than the full fiscal quarter, i.e. three-month period.</helptext>
+        <helptext id="numSubminimalWageWorkersTotalHelp">Provide the total number of workers with disabilities who were paid subminimum wages at all establishments and work sites during the most recently completed fiscal quarter. Include workers who were employed for less than the full fiscal quarter, i.e. three-month period.</helptext>
       </div>
       <span class="usa-input-error-message" role="alert" ng-show="validate('employer.numSubminimalWageWorkers.total')">{{ validate('employer.numSubminimalWageWorkers.total') }}</span>
       <div class="form-question-answer">
-        <input id="numSubminimalWageWorkersTotal" name="numSubminimalWageWorkersTotal" type="number" class="numeric7" min="0" step="1" ng-model="formData.employer.numSubminimalWageWorkers.total">
+        <input id="numSubminimalWageWorkersTotal" name="numSubminimalWageWorkersTotal" aria-describedby="numSubminimalWageWorkersTotalHelp" type="number" class="numeric7" min="0" step="1" ng-model="formData.employer.numSubminimalWageWorkers.total">
       </div>
     </div>
     <div class="form-question-block">
       <div class="form-question-text">Provide the number of workers with disabilities employed at subminimum wages for the most recently completed fiscal quarter in each of the following categories:
         <helplink></helplink>
-        <helptext>Provide the number of workers with disabilities for the same period employed at subminimum wages in the specified categories. Refer to the definitions provided in the instructions for Item 2(a).</helptext>
+        <helptext id="numSubminimalWageWorkersWorkCenterHelp">Provide the number of workers with disabilities for the same period employed at subminimum wages in the specified categories. Refer to the definitions provided in the instructions for Item 2(a).</helptext>
       </div>
       <div ng-class="validate('employer.numSubminimalWageWorkers.workCenter') ? 'usa-input-error' : ''">
         <label for="numSubminimalWageWorkersWorkCenter">Community Rehabilitation Program (Work Center)</label>
         <span class="usa-input-error-message" role="alert" ng-show="validate('employer.numSubminimalWageWorkers.workCenter')">{{ validate('employer.numSubminimalWageWorkers.workCenter') }}</span>
         <div class="form-question-answer">
-          <input id="numSubminimalWageWorkersWorkCenter" name="numSubminimalWageWorkersWorkCenter" type="number" class="numeric7" min="0" step="1" ng-model="formData.employer.numSubminimalWageWorkers.workCenter">
+          <input id="numSubminimalWageWorkersWorkCenter" name="numSubminimalWageWorkersWorkCenter" aria-describedby="numSubminimalWageWorkersWorkCenterHelp" type="number" class="numeric7" min="0" step="1" ng-model="formData.employer.numSubminimalWageWorkers.workCenter">
         </div>
       </div>
       <div ng-class="validate('employer.numSubminimalWageWorkers.patientWorkers') ? 'usa-input-error' : ''">
@@ -341,18 +341,18 @@
   <div class="form-question-block" ng-class="validate('employer.pca') ? 'usa-input-error' : ''">
     <div class="form-question-text">Does this employer manufacture items for the Federal Government under the Walsh-Healey Public Contracts Act (PCA)?
       <helplink></helplink>
-      <helptext>Make the appropriate selection if the employer has, or intends to receive, any contracts with the Federal Government subject to the Walsh-Healey Public Contracts Act (PCA). Additional information about contracts with the Federal Government can be found at <a href="www.dol.gov/whd/govcontracts/">www.dol.gov/whd/govcontracts/</a>.</helptext>
+      <helptext id="PCAHelp">Make the appropriate selection if the employer has, or intends to receive, any contracts with the Federal Government subject to the Walsh-Healey Public Contracts Act (PCA). Additional information about contracts with the Federal Government can be found at <a href="www.dol.gov/whd/govcontracts/">www.dol.gov/whd/govcontracts/</a>.</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('employer.pca')">{{ validate('employer.pca') }}</span>
     <fieldset class="usa-fieldset-inputs form-question-answer">
       <legend class="hide">PCA?</legend>
       <ul class="usa-unstyled-list">
         <li>
-          <input id="PCA_1" type="radio" name="PCA" ng-value="true" ng-model="formData.employer.pca">
+          <input id="PCA_1" type="radio" name="PCA" aria-describedby="PCAHelp" ng-value="true" ng-model="formData.employer.pca">
           <label for="PCA_1">Yes</label>
         </li>
         <li>
-          <input id="PCA_0" type="radio" name="PCA" ng-value="false" ng-model="formData.employer.pca">
+          <input id="PCA_0" type="radio" name="PCA" aria-describedby="PCAHelp" ng-value="false" ng-model="formData.employer.pca">
           <label for="PCA_0">No</label>
         </li>
       </ul>
@@ -361,14 +361,14 @@
   <div class="form-question-block" ng-class="validate('employer.scaId') ? 'usa-input-error' : ''">
     <div class="form-question-text">Does this employer currently hold any contracts covered by the McNamara-O’Hara Service Contract Act (SCA)?
       <helplink></helplink>
-      <helptext>Make the appropriate selection if the employer has, or intends to receive, any contracts with the McNamara-O’Hara Service Contract Act (SCA). If the employer had one or more SCA-covered. Additional information about contracts with the Federal Government can be found at <a href="www.dol.gov/whd/govcontracts/">www.dol.gov/whd/govcontracts/</a>.</helptext>
+      <helptext id="SCAHelp">Make the appropriate selection if the employer has, or intends to receive, any contracts with the McNamara-O’Hara Service Contract Act (SCA). If the employer had one or more SCA-covered. Additional information about contracts with the Federal Government can be found at <a href="www.dol.gov/whd/govcontracts/">www.dol.gov/whd/govcontracts/</a>.</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('employer.scaId')">{{ validate('employer.scaId') }}</span>
     <fieldset class="usa-fieldset-inputs form-question-answer">
       <legend class="hide">SCA?</legend>
       <ul class="usa-unstyled-list">
         <li ng-repeat="response in responses.SCA">
-          <input id="SCA_{{ response.id }}" type="radio" name="SCA" ng-value="response.id" ng-model="formData.employer.scaId">
+          <input id="SCA_{{ response.id }}" type="radio" name="SCA" aria-describedby="SCAHelp" ng-value="response.id" ng-model="formData.employer.scaId">
           <label for="SCA_{{ response.id }}">{{ response.display }}</label>
         </li>
       </ul>
@@ -391,14 +391,14 @@
   <div class="form-question-block" ng-class="validate('employer.eo13658Id') ? 'usa-input-error' : ''">
     <div class="form-question-text">Since January 1, 2015, has this employer entered into a contract for services or concessions with the Federal Government that may be subject to Executive Order 13658 (Establishing a Minimum Wage for Contractors)?
       <helplink></helplink>
-      <helptext>Make the appropriate selection if the employer has, or intends to receive, any contracts with the Federal Government subject to Executive Order 13658, Establishing a Minimum Wage for Contractors. Section 14(c) workers performing on or in connection with a contract covered by Executive Order 13658 are generally entitled to be paid at least the Executive Order minimum wage. Additional information about contracts with the Federal Government can be found at <a href="www.dol.gov/whd/govcontracts/">www.dol.gov/whd/govcontracts/</a>.</helptext>
+      <helptext id="EO13658Help">Make the appropriate selection if the employer has, or intends to receive, any contracts with the Federal Government subject to Executive Order 13658, Establishing a Minimum Wage for Contractors. Section 14(c) workers performing on or in connection with a contract covered by Executive Order 13658 are generally entitled to be paid at least the Executive Order minimum wage. Additional information about contracts with the Federal Government can be found at <a href="www.dol.gov/whd/govcontracts/">www.dol.gov/whd/govcontracts/</a>.</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('employer.eo13658Id')">{{ validate('employer.eo13658Id') }}</span>
     <fieldset class="usa-fieldset-inputs form-question-answer">
       <legend class="hide">Subject to EO13658?</legend>
       <ul class="usa-unstyled-list">
         <li ng-repeat="response in responses.EO13658">
-          <input id="EO13658_{{ response.id }}" type="radio" name="EO13658" ng-value="response.id" ng-model="formData.employer.eo13658Id">
+          <input id="EO13658_{{ response.id }}" type="radio" name="EO13658" aria-describedby="EO13658Help" ng-value="response.id" ng-model="formData.employer.eo13658Id">
           <label for="EO13658_{{ response.id }}">{{ response.display }}</label>
         </li>
       </ul>
@@ -409,18 +409,18 @@
   <div class="form-question-block" ng-class="validate('employer.representativePayee') ? 'usa-input-error' : ''">
     <div class="form-question-text">Was the employer a representative payee for any worker with disabilities and, as such, received Social Security Benefits such as Supplemental Security Income (SSI) or Social Security Disability Insurance (SSDI) on behalf of that employee during the most recently completed fiscal quarter?
       <helplink></helplink>
-      <helptext>If the employer was a representative payee for any worker with disabilities who received Social Security benefits during the most recently completed fiscal quarter, provide the total number of employees for whom the employer was the representative payee.</helptext>
+      <helptext id="representativePayeeHelp">If the employer was a representative payee for any worker with disabilities who received Social Security benefits during the most recently completed fiscal quarter, provide the total number of employees for whom the employer was the representative payee.</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('employer.representativePayee')">{{ validate('employer.representativePayee') }}</span>
     <fieldset class="usa-fieldset-inputs form-question-answer">
       <legend class="hide">Representative payee</legend>
       <ul class="usa-unstyled-list">
         <li>
-          <input id="representativePayee_1" type="radio" name="representativePayee" ng-value="true" ng-model="formData.employer.representativePayee">
+          <input id="representativePayee_1" type="radio" name="representativePayee" aria-describedby="representativePayeeHelp" ng-value="true" ng-model="formData.employer.representativePayee">
           <label for="representativePayee_1">Yes</label>
         </li>
         <li>
-          <input id="representativePayee_0" type="radio" name="representativePayee" ng-value="false" ng-model="formData.employer.representativePayee">
+          <input id="representativePayee_0" type="radio" name="representativePayee" aria-describedby="representativePayeeHelp" ng-value="false" ng-model="formData.employer.representativePayee">
           <label for="representativePayee_0">No</label>
         </li>
       </ul>
@@ -438,18 +438,18 @@
   <div class="form-question-block" ng-class="validate('employer.takeCreditForCosts') ? 'usa-input-error' : ''">
     <div class="form-question-text">Did the employer take credit for the cost of providing facilities, such as board, lodging, and transportation, toward meeting the minimum wage or subminimum wage obligations during the most recently completed fiscal quarter?
       <helplink></helplink>
-      <helptext>Indicate if the employer provided facilities such as lodging, board, and transportation to any employee, and took credit for those costs toward meeting the minimum wage or subminimum wage obligations to employees with disabilities during the most recently completed fiscal quarter. See 29 C.F.R. § 531 and 29 C.F.R. § 516.</helptext>
+      <helptext id="takeCreditForCostsHelp">Indicate if the employer provided facilities such as lodging, board, and transportation to any employee, and took credit for those costs toward meeting the minimum wage or subminimum wage obligations to employees with disabilities during the most recently completed fiscal quarter. See 29 C.F.R. § 531 and 29 C.F.R. § 516.</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('employer.takeCreditForCosts')">{{ validate('employer.takeCreditForCosts') }}</span>
     <fieldset class="usa-fieldset-inputs form-question-answer">
       <legend class="hide">Take credit for costs</legend>
       <ul class="usa-unstyled-list">
         <li>
-          <input id="takeCreditForCosts_1" type="radio" name="takeCreditForCosts" ng-value="true" ng-model="formData.employer.takeCreditForCosts">
+          <input id="takeCreditForCosts_1" type="radio" name="takeCreditForCosts" aria-describedby="takeCreditForCostsHelp" ng-value="true" ng-model="formData.employer.takeCreditForCosts">
           <label for="takeCreditForCosts_1">Yes</label>
         </li>
         <li>
-          <input id="takeCreditForCosts_0" type="radio" name="takeCreditForCosts" ng-value="false" ng-model="formData.employer.takeCreditForCosts">
+          <input id="takeCreditForCosts_0" type="radio" name="takeCreditForCosts" aria-describedby="takeCreditForCostsHelp" ng-value="false" ng-model="formData.employer.takeCreditForCosts">
           <label for="takeCreditForCosts_0">No</label>
         </li>
       </ul>
@@ -472,18 +472,18 @@
     <div class="form-question-text">
       Is this a request for Temporary Authority by a vocational rehabilitation program administered by a State agency or the U.S. Veterans Administration?
       <helplink></helplink>
-      <helptext>Select “Yes” only if the application is being filed by a vocational rehabilitation program administered by a State agency or the U.S. Veterans Administration. See 29 C.F.R. § 525.8.</helptext>
+      <helptext id="temporaryAuthorityHelp">Select “Yes” only if the application is being filed by a vocational rehabilitation program administered by a State agency or the U.S. Veterans Administration. See 29 C.F.R. § 525.8.</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('employer.temporaryAuthority')">{{ validate('employer.temporaryAuthority') }}</span>
     <fieldset class="usa-fieldset-inputs form-question-answer">
       <legend class="hide">Temporary authority</legend>
       <ul class="usa-unstyled-list">
         <li>
-          <input id="temporaryAuthority_1" type="radio" name="temporaryAuthority" ng-value="true" ng-model="formData.employer.temporaryAuthority">
+          <input id="temporaryAuthority_1" type="radio" name="temporaryAuthority" aria-describedby="temporaryAuthorityHelp" ng-value="true" ng-model="formData.employer.temporaryAuthority">
           <label for="temporaryAuthority_1">Yes</label>
         </li>
         <li>
-          <input id="temporaryAuthority_0" type="radio" name="temporaryAuthority" ng-value="false" ng-model="formData.employer.temporaryAuthority">
+          <input id="temporaryAuthority_0" type="radio" name="temporaryAuthority" aria-describedby="temporaryAuthorityHelp" ng-value="false" ng-model="formData.employer.temporaryAuthority">
           <label for="temporaryAuthority_0">No</label>
         </li>
       </ul>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/wageDataPayTypeFormTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/wageDataPayTypeFormTemplate.html
@@ -3,11 +3,11 @@
     <div class="form-question-text">
       {{ paytype === 'hourly' ? 'How many workers with disabilities were paid an hourly subminimum wage during the most recently completed fiscal quarter?' : 'How many workers with disabilities received subminimum wages and were paid piece rates during the most recently completed fiscal quarter?' }}
       <helplink></helplink>
-      <helptext>Count the total number of workers paid {{ paytype === 'an hourly' ? 'hourly' : 'a piece rate'}} subminimum wage rate at any time during the most recently completed fiscalquarter that ended on the date listed in Item 7(a).</helptext>
+      <helptext id="numWorkersHelp">Count the total number of workers paid {{ paytype === 'an hourly' ? 'hourly' : 'a piece rate'}} subminimum wage rate at any time during the most recently completed fiscalquarter that ended on the date listed in Item 7(a).</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.numWorkers')">{{ validate(modelPrefix() + '.numWorkers') }}</span>
     <div class="form-question-answer">
-      <input id="numWorkers" name="numWorkers" type="number" class="numeric7" min="0" step="1" ng-model="formData[modelPrefix()].numWorkers">
+      <input id="numWorkers" name="numWorkers" aria-describedby="numWorkersHelp" type="number" class="numeric7" min="0" step="1" ng-model="formData[modelPrefix()].numWorkers">
     </div>
   </div>
 
@@ -15,12 +15,12 @@
     <div class="form-question-text">
       What was the job or contract on which the employer employed the largest number of workers at hourly subminimum wage rates during the most recently completed fiscal quarter?
       <helplink></helplink>
-      <helptext>Identify the job or contract and provide a brief description of the work performed by workers paid subminimum wages (e.g., Name: Kitchen cleaning, Description: sink, counters, stove, refrigerator, microwave cleaning duties, or Name: Contract No. 123-456 with Sheets Inc., Description: Laundry Service).</helptext>
+      <helptext id="jobNameHelp">Identify the job or contract and provide a brief description of the work performed by workers paid subminimum wages (e.g., Name: Kitchen cleaning, Description: sink, counters, stove, refrigerator, microwave cleaning duties, or Name: Contract No. 123-456 with Sheets Inc., Description: Laundry Service).</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.jobName')">{{ validate(modelPrefix() + '.jobName') }}</span>
     <div class="form-question-answer">
       <label for="jobName">Name of Job or Contract</label>
-      <input id="jobName" name="jobName" type="text" ng-model="formData[modelPrefix()].jobName">
+      <input id="jobName" name="jobName" aria-describedby="jobNameHelp" type="text" ng-model="formData[modelPrefix()].jobName">
     </div>
   </div>
 
@@ -36,7 +36,7 @@
     <div class="form-question-text">
       Which method did the employer use to determine the Prevailing Wage for the job or contract identified above?
       <helplink></helplink>
-      <helptext>
+      <helptext id="wageMethodHelp">
         For information on Prevailing Wages, see <a href='https://www.dol.gov/whd/regs/compliance/whdfs39b.pdf' target='_blank'>Fact Sheet #39B: Prevailing Wages and Commensurate Wages under Section 14(c) of the FLSA</a>.
       </helptext>
     </div>
@@ -46,7 +46,7 @@
 
       <ul class="usa-unstyled-list">
         <li ng-repeat="response in responses.PrevailingWageMethod">
-          <input id="wagemethod_{{ response.id }}" type="radio" name="wage-method" ng-value="response.id" ng-model="formData[modelPrefix()].prevailingWageMethodId">
+          <input id="wagemethod_{{ response.id }}" type="radio" name="wage-method" aria-describedby="wageMethodHelp" ng-value="response.id" ng-model="formData[modelPrefix()].prevailingWageMethodId">
           <label for="wagemethod_{{ response.id }}">{{ response.display }}</label>
         </li>
       </ul>
@@ -64,7 +64,7 @@
         </div>
         <label>You must provide <strong>3</strong> Source Employers for the survey
           <helplink></helplink>
-          <helptext>
+          <helptext id="sourceEmployerNameHelp">
             <p>The source employers surveyed should be located in the geographic area from which the labor force of the applicant is drawn. The sources for the jobs surveyed should use similar methods and equipment as the job for which this rate will apply.</p>
             <p>The wage rate collected from each source should be the hourly rate paid to experienced (not entry level) workers who do not have disabilities that affect productive capacity.</p>
             <p>An experienced worker is a worker who has learned the basic requirements of the work to be performed, ordinarily by completion of a probationary or training period. Typically, an experienced worker will have received at least one pay raise after successful completion of the probationary or training period.</p>
@@ -75,7 +75,7 @@
           <div ng-class="vm.validateActiveSourceEmployerProperty('employerName') ? 'usa-input-error' : ''">
             <label for="sourceEmployerName">Source Employer Name</label>
             <span class="usa-input-error-message" role="alert" ng-show="vm.validateActiveSourceEmployerProperty('employerName')">{{ vm.validateActiveSourceEmployerProperty('employerName') }}</span>
-            <input id="sourceEmployerName" name="sourceEmployerName" type="text" ng-model="vm.activeSourceEmployer.employerName">
+            <input id="sourceEmployerName" name="sourceEmployerName" aria-describedby="sourceEmployerNameHelp" type="text" ng-model="vm.activeSourceEmployer.employerName">
           </div>
 
           <div class="usa-form-large">
@@ -257,7 +257,7 @@
     <div class="form-question-block">
       <div class="form-question-text">Provide the alternate wage data source used and the prevailing wage provided by that source:
         <helplink></helplink>
-        <helptext>
+        <helptext id="alternateWorkDescriptionHelp">
           <p>If conducting surveys is not practical and the employer instead uses U.S. Bureau of Labor Statistics (BLS) or alternative wage rates, identify the alternative source used (e.g., BLS Occupational Employment Survey; BLS Current Population Survey), the prevailing wage, the job classification (if applicable) provided by the source, and the date that the data was obtained.</p>
           <p>BLS wage data can be found at <a href="www.bls.gov/bls/blswage.htm">www.bls.gov/bls/blswage.htm</a>.</p>
           <p>Data from employment services may only be used to determine prevailing wages if the data provides wage rates of experienced workers not disabled for the work being performed; entry level wage data may not be used.</p>
@@ -268,7 +268,7 @@
           <div ng-class="validate(modelPrefix() + '.alternateWageData.alternateWorkDescription') ? 'usa-input-error' : ''">
             <label for="alternateWorkDescription">Description of Work (include job classification code, if known)</label>
             <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.alternateWageData.alternateWorkDescription')">{{ validate(modelPrefix() + '.alternateWageData.alternateWorkDescription') }}</span>
-            <textarea id="alternateWorkDescription" name="alternateWorkDescription" ng-model="formData[modelPrefix()].alternateWageData.alternateWorkDescription"></textarea>
+            <textarea id="alternateWorkDescription" name="alternateWorkDescription" aria-describedby="alternateWorkDescriptionHelp" ng-model="formData[modelPrefix()].alternateWageData.alternateWorkDescription"></textarea>
           </div>
 
           <div ng-class="validate(modelPrefix() + '.alternateWageData.alternateDataSourceUsed') ? 'usa-input-error' : ''">
@@ -301,7 +301,7 @@
     <div class="form-question-block" ng-class="validate(modelPrefix() + '.scaWageDeterminationAttachmentId') ? 'usa-input-error' : ''">
       <div class="form-question-text">Attach the applicable SCA Wage Determination
         <helplink></helplink>
-        <helptext>
+        <helptext id="scaWageDeterminationAttachmentHelp">
           <p>If conducting surveys is not practical and the employer instead uses U.S. Bureau of Labor Statistics (BLS) or alternative wage rates, identify the alternative source used (e.g., BLS Occupational Employment Survey; BLS Current Population Survey), the prevailing wage, the job classification (if applicable) provided by the source, and the date that the data was obtained.</p>
           <p>BLS wage data can be found at <a href="www.bls.gov/bls/blswage.htm">www.bls.gov/bls/blswage.htm</a>.</p>
           <p>Data from employment services may only be used to determine prevailing wages if the data provides wage rates of experienced workers not disabled for the work being performed; entry level wage data may not be used.</p>
@@ -317,12 +317,12 @@
       <div class="form-question-text">
         How frequently does the employer conduct work measurements or time studies of each worker with a disability who is paid an hourly subminimum wage?
         <helplink></helplink>
-        <helptext>Indicate how frequently the employer conducts work measurements or time studies of each worker with a disability who is paid anhourly subminimum wage.</helptext>
+        <helptext id="workMeasurementFrequencyHelp">Indicate how frequently the employer conducts work measurements or time studies of each worker with a disability who is paid anhourly subminimum wage.</helptext>
       </div>
       <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.workMeasurementFrequency')">{{ validate(modelPrefix() + '.workMeasurementFrequency') }}</span>
       <div class="form-question-answer">
         <label for="workMeasurementFrequency" class="hide">Work measurement frequency</label>
-        <input id="workMeasurementFrequency" name="workMeasurementFrequency" type="text" ng-model="formData[modelPrefix()].workMeasurementFrequency">
+        <input id="workMeasurementFrequency" name="workMeasurementFrequency" aria-describedby="workMeasurementFrequencyHelp" type="text" ng-model="formData[modelPrefix()].workMeasurementFrequency">
       </div>
     </div>
 
@@ -330,7 +330,7 @@
       <div class="form-question-text">
         Attach a work measurement or time study for ONE currently employed worker with a disability who is paid an hourly subminimum wage for the contract identified above.
         <helplink></helplink>
-        <helptext>Select one time study for a worker who was paid an hourly subminimum wage under the same job/contract reflected in Item 9(b). The time study provided must be the most recent time study conducted for that worker. The hourly rate time study providedshould include the productivity rating and evaluation forms used to determine the employee’s commensurate wage rate. The documentation should include all materials related to the work measurement, such as:
+        <helptext id="workMeasurementAttachmentHelp">Select one time study for a worker who was paid an hourly subminimum wage under the same job/contract reflected in Item 9(b). The time study provided must be the most recent time study conducted for that worker. The hourly rate time study providedshould include the productivity rating and evaluation forms used to determine the employee’s commensurate wage rate. The documentation should include all materials related to the work measurement, such as:
           <ul>
             <li>detailed task analysis (including quality and quantity measures),</li>
             <li>wage and productivity of an experienced worker who is not disabled for the work performing the same job(i.e., "standard setter"), and</li>
@@ -347,13 +347,13 @@
     <div class="form-question-block">
       <div class="form-question-text">Provide the following information for the job or contract identified above:
         <helplink></helplink>
-        <helptext>Provide a current piece rate work measurement or time study for the job/contract reflected in the prevailing wage survey provided in Item 11(b). Provide the description of the job tasks, the hourly prevailing wage for the job, the standard productivity (units per hour), and the piece rate paid to workers (rate per unit).</helptext>
+        <helptext id="pieceRateWorkDescriptionHelp">Provide a current piece rate work measurement or time study for the job/contract reflected in the prevailing wage survey provided in Item 11(b). Provide the description of the job tasks, the hourly prevailing wage for the job, the standard productivity (units per hour), and the piece rate paid to workers (rate per unit).</helptext>
       </div>
       <div class="form-question-answer">
         <div ng-class="validate(modelPrefix() + '.pieceRateWorkDescription') ? 'usa-input-error' : ''">
           <label for="pieceRateWorkDescription">Descripton of Work</label>
           <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.pieceRateWorkDescription')">{{ validate(modelPrefix() + '.pieceRateWorkDescription') }}</span>
-          <input id="pieceRateWorkDescription" name="pieceRateWorkDescription" type="text" ng-model="formData[modelPrefix()].pieceRateWorkDescription">
+          <input id="pieceRateWorkDescription" name="pieceRateWorkDescription" aria-describedby="pieceRateWorkDescriptionHelp" type="text" ng-model="formData[modelPrefix()].pieceRateWorkDescription">
         </div>
 
         <div ng-class="validate(modelPrefix() + '.prevailingWageDeterminedForJob') ? 'usa-input-error' : ''">
@@ -382,7 +382,7 @@
     <div class="form-question-block" ng-class="validate(modelPrefix() + '.attachmentId') ? 'usa-input-error' : ''">
       <div class="form-question-text">Attach all documents of the methods used to determine the standard productivity and the piece rate.
         <helplink></helplink>
-        <helptext>Attach all documentation of the methods used to determine the standard productivity and the piece rate, such as:
+        <helptext id="standardProductivityAttachmentHelp">Attach all documentation of the methods used to determine the standard productivity and the piece rate, such as:
           <ul>
             <li>detailed task analysis (including quality and quantity measures), and</li>
             <li>productivity of an experienced worker who is not disabled for the work performing the same job (i.e., “standard setter”).</li>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionWioa/sectionWioaTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionWioa/sectionWioaTemplate.html
@@ -48,18 +48,18 @@
   <div class="form-question-block" ng-class="validate('WIOA.hasWIOAWorkers') ? 'usa-input-error' : ''">
     <div class="form-question-text">Were any workers paid a subminimum wage age 24 or younger?
       <helplink></helplink>
-      <helptext>List the name of each worker with a disability age 24 or younger and provide a response for each individual. Answer “Y” if the employer has reviewed, verified, and maintained documentation from the individual showing that the requirements described above have been completed. Answer “N” if the employer has not verified that these requirements have been completed for this individual or if these requirements have not yet been completed. Answer “NR” if the employer is aware that the individual was employed on July 22, 2016 by this employer or by another entity that held a section 14(c) certificate.</helptext>
+      <helptext id="hasWIOAWorkersHelp">List the name of each worker with a disability age 24 or younger and provide a response for each individual. Answer “Y” if the employer has reviewed, verified, and maintained documentation from the individual showing that the requirements described above have been completed. Answer “N” if the employer has not verified that these requirements have been completed for this individual or if these requirements have not yet been completed. Answer “NR” if the employer is aware that the individual was employed on July 22, 2016 by this employer or by another entity that held a section 14(c) certificate.</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('WIOA.hasWIOAWorkers')">{{ validate('WIOA.hasWIOAWorkers') }}</span>
     <fieldset class="usa-fieldset-inputs form-question-answer">
       <legend class="hide">Has WIOA workers?</legend>
       <ul class="usa-unstyled-list">
         <li>
-          <input id="hasWIOAWorkers_1" type="radio" name="hasWIOAWorkers" ng-value="true" ng-model="formData.WIOA.hasWIOAWorkers">
+          <input id="hasWIOAWorkers_1" type="radio" name="hasWIOAWorkers" aria-describedby="hasWIOAWorkersHelp" ng-value="true" ng-model="formData.WIOA.hasWIOAWorkers">
           <label for="hasWIOAWorkers_1">Yes</label>
         </li>
         <li>
-          <input id="hasWIOAWorkers_0" type="radio" name="hasWIOAWorkers" ng-value="false" ng-model="formData.WIOA.hasWIOAWorkers">
+          <input id="hasWIOAWorkers_0" type="radio" name="hasWIOAWorkers" aria-describedby="hasWIOAWorkersHelp" ng-value="false" ng-model="formData.WIOA.hasWIOAWorkers">
           <label for="hasWIOAWorkers_0">No</label>
         </li>
       </ul>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionWorkSites/sectionWorkSitesTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionWorkSites/sectionWorkSitesTemplate.html
@@ -18,11 +18,11 @@
   <div class="form-question-block" ng-class="validate('totalNumWorkSites') ? 'usa-input-error' : ''">
     <div class="form-question-text">What is the total number of establishments and work sites to be covered by this certificate?
       <helplink></helplink>
-      <helptext>Provide the total number of work sites for which the employer is seeking approval to employ workers at subminimum wages. Count all work sites, including the main establishment and any branch establishments, off-site work locations, and/or SWEP work sites.</helptext>
+      <helptext id="numWorkSitesHelp">Provide the total number of work sites for which the employer is seeking approval to employ workers at subminimum wages. Count all work sites, including the main establishment and any branch establishments, off-site work locations, and/or SWEP work sites.</helptext>
     </div>
     <span class="usa-input-error-message" role="alert" ng-show="validate('totalNumWorkSites')">{{ validate('totalNumWorkSites') }}</span>
     <div class="form-question-answer">
-      <input id="numWorkSites" name="numWorkSites" type="number" class="numeric7" min="0" step="1" ng-model="formData.totalNumWorkSites">
+      <input id="numWorkSites" name="numWorkSites" aria-describedby="numWorkSitesHelp" type="number" class="numeric7" min="0" step="1" ng-model="formData.totalNumWorkSites">
     </div>
   </div>
 
@@ -48,7 +48,7 @@
     <div class="form-question-block" ng-class="vm.validateActiveWorksiteProperty('type') ? 'usa-input-error' : ''">
       <div class="form-question-text">What type of establishment is this?
         <helplink></helplink>
-        <helptext>
+        <helptext id="establishmentTypeHelp">
           <p>Indicate whether the work site is the main establishment, a branch establishment, an off-site work location, or a School Work Experience Program work site.</p>
           <p><strong>Main Establishment:</strong> The primary location of the employer that files this application on behalf of all its associated work sites. (There can only be one main establishment.)</p>
           <p><strong>Branch Establishment:</strong> A branch establishment is a physically separate work site that is part of the same organization as the main establishment.</p>
@@ -62,7 +62,7 @@
           <legend class="hide">Work site type</legend>
           <ul class="usa-unstyled-list">
             <li ng-repeat="response in responses.WorkSiteType">
-              <input id="establishmentType_{{ response.id }}" type="radio" name="establishmentType" ng-value="{{ response.id }}" ng-model="vm.activeWorksite.workSiteTypeId">
+              <input id="establishmentType_{{ response.id }}" type="radio" name="establishmentType" aria-describedby="establishmentTypeHelp" ng-value="{{ response.id }}" ng-model="vm.activeWorksite.workSiteTypeId">
               <label for="establishmentType_{{ response.id }}">{{ response.display }}</label>
               <div class="underlabel checkbox-indent">{{ response.subDisplay }}</div>
             </li>
@@ -119,7 +119,7 @@
     <div class="form-question-block" class="form-question-block" ng-class="vm.validateActiveWorksiteProperty('sca') ? 'usa-input-error' : ''">
       <div class="form-question-text">Is Service Contract Act (SCA)-covered work performed at this establishment / work site?
         <helplink></helplink>
-        <helptext>Mark "yes" if the employer has a Service Contract Act (SCA)-covered contract to provide services to the Federal Government and work under that contract is performed at this work site.</helptext>
+        <helptext id="worksiteScaHelp">Mark "yes" if the employer has a Service Contract Act (SCA)-covered contract to provide services to the Federal Government and work under that contract is performed at this work site.</helptext>
       </div>
       <span class="usa-input-error-message" role="alert" ng-show="vm.validateActiveWorksiteProperty('sca')">{{ vm.validateActiveWorksiteProperty('sca') }}</span>
       <div class="form-question-answer">
@@ -127,11 +127,11 @@
           <legend class="hide">(SCA)-covered?</legend>
           <ul class="usa-unstyled-list">
             <li>
-              <input id="worksiteScaYes" type="radio" name="worksiteSca" ng-value="true" ng-model="vm.activeWorksite.sca">
+              <input id="worksiteScaYes" type="radio" name="worksiteSca" aria-describedby="worksiteScaHelp" ng-value="true" ng-model="vm.activeWorksite.sca">
               <label for="worksiteScaYes">Yes</label>
             </li>
             <li>
-              <input id="worksiteScaNo" type="radio" name="worksiteSca" ng-value="false" ng-model="vm.activeWorksite.sca">
+              <input id="worksiteScaNo" type="radio" name="worksiteSca" aria-describedby="worksiteScaHelp" ng-value="false" ng-model="vm.activeWorksite.sca">
               <label for="worksiteScaNo">No</label>
             </li>
           </ul>
@@ -142,7 +142,7 @@
     <div class="form-question-block" class="form-question-block" ng-class="vm.validateActiveWorksiteProperty('federalContractWorkPerformed') ? 'usa-input-error' : ''">
       <div class="form-question-text">Is work performed at this establishment / work site pursuant to a Federal contract for services or concessions that was entered into on or after January 1, 2015, which indicates that the contract may be subject to Executive Order 13658 (Establishing a Minimum Wage for Contractors)?
         <helplink></helplink>
-        <helptext>Mark “yes” if the employer has a contract with the Federal Government for services or concessions that was entered into on or after January 1, 2015, which indicates that the contract may be subject to <a href='https://www.federalregister.gov/documents/2014/02/20/2014-03805/establishing-a-minimum-wage-for-contractors' target='_blank'>Executive Order 13658</a> (Establishing a Minimum Wage for Contractors).</helptext>
+        <helptext id="worksiteFederalHelp">Mark “yes” if the employer has a contract with the Federal Government for services or concessions that was entered into on or after January 1, 2015, which indicates that the contract may be subject to <a href='https://www.federalregister.gov/documents/2014/02/20/2014-03805/establishing-a-minimum-wage-for-contractors' target='_blank'>Executive Order 13658</a> (Establishing a Minimum Wage for Contractors).</helptext>
       </div>
       <span class="usa-input-error-message" role="alert" ng-show="vm.validateActiveWorksiteProperty('federalContractWorkPerformed')">{{ vm.validateActiveWorksiteProperty('federalContractWorkPerformed') }}</span>
       <div class="form-question-answer">
@@ -150,11 +150,11 @@
           <legend class="hide">Federal contract work performed?</legend>
           <ul class="usa-unstyled-list">
             <li>
-              <input id="worksiteFederalYes" type="radio" name="worksiteFederal" ng-value="true" ng-model="vm.activeWorksite.federalContractWorkPerformed">
+              <input id="worksiteFederalYes" type="radio" name="worksiteFederal" aria-describedby="worksiteFederalHelp" ng-value="true" ng-model="vm.activeWorksite.federalContractWorkPerformed">
               <label for="worksiteFederalYes">Yes</label>
             </li>
             <li>
-              <input id="worksiteFederalNo" type="radio" name="worksiteFederal" ng-value="false" ng-model="vm.activeWorksite.federalContractWorkPerformed">
+              <input id="worksiteFederalNo" type="radio" name="worksiteFederal" aria-describedby="worksiteFederalHelp" ng-value="false" ng-model="vm.activeWorksite.federalContractWorkPerformed">
               <label for="worksiteFederalNo">No</label>
             </li>
           </ul>
@@ -165,11 +165,11 @@
     <div class="form-question-block" class="form-question-block" ng-class="vm.validateActiveWorksiteProperty('numEmployees') ? 'usa-input-error' : ''" ng-show="vm.notInitialApp()">
       <div class="form-question-text">Total number of employees who were employed at this establishment/work site at any time during the most recently completed fiscal quarter and received subminimum wages:
         <helplink></helplink>
-        <helptext>Count all employees who were paid subminimum wages and performed work at this work site during the most recently completed fiscal quarter that ended on the date provided in Item 7(a) of the WH-226. Include workers who were employed for less than the full fiscal quarter, i.e. three-month period.</helptext>
+        <helptext id="worksiteNumEmployeesHelp">Count all employees who were paid subminimum wages and performed work at this work site during the most recently completed fiscal quarter that ended on the date provided in Item 7(a) of the WH-226. Include workers who were employed for less than the full fiscal quarter, i.e. three-month period.</helptext>
       </div>
       <span class="usa-input-error-message" role="alert" ng-show="vm.validateActiveWorksiteProperty('numEmployees')">{{ vm.validateActiveWorksiteProperty('numEmployees') }}</span>
       <div class="form-question-answer">
-        <input id="worksiteNumEmployees" name="worksiteNumEmployees" type="number" class="numeric7" min="0" step="1" ng-model="vm.activeWorksite.numEmployees">
+        <input id="worksiteNumEmployees" name="worksiteNumEmployees" aria-describedby="worksiteNumEmployeesHelp" type="number" class="numeric7" min="0" step="1" ng-model="vm.activeWorksite.numEmployees">
       </div>
     </div>
   </div>


### PR DESCRIPTION
Quick follow-up on https://github.com/18F/dol-whd-14c/pull/255

the help text content blocks should now be explicitly associated with the form control it relates to using the `aria-describedby` attribute.