### PR TITLE
make section nav keyboard navigate-able

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/components/mainNavigationControl/mainNavigationControlController.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/mainNavigationControl/mainNavigationControlController.js
@@ -22,5 +22,9 @@ module.exports = function(ngModule) {
       var id = event.target.dataset.sectionid;
       navService.gotoSection(id);
     };
+
+    this.onKeyPress = e => {
+      if (e.which === 13) this.onNavClick(e);
+    };
   });
 };

--- a/DOL.WHD.Section14c.Web/src/modules/components/mainNavigationControl/mainNavigationControlTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/mainNavigationControl/mainNavigationControlTemplate.html
@@ -1,6 +1,16 @@
 <button class="dol-nav-toggle" type="button" ng-click="vm.collapseMenu = !vm.collapseMenu">Form Menu</button>
 <nav role="navigation" class="main-nav-bar" ng-class="vm.collapseMenu ? 'collapsed' : ''">
   <ul>
-    <li ng-repeat="section in vm.navService.getSections()" class="nav-button {{ vm.current === section.id ? 'active' : '' }}" data-sectionid="{{ section.id }}" ng-click="vm.onNavClick($event)" ng-show="section.id !== 'review' || vm.stateService.inReview">{{ section.display }}</li>
+    <li
+      ng-repeat="section in vm.navService.getSections()"
+      class="nav-button {{ vm.current === section.id ? 'active' : '' }}"
+      data-sectionid="{{ section.id }}"
+      ng-click="vm.onNavClick($event)"
+      ng-keypress="vm.onKeyPress($event)"
+      ng-show="section.id !== 'review' || vm.stateService.inReview"
+      tabindex="0"
+    >
+      {{ section.display }}
+    </li>
   </ul>
 </nav>


### PR DESCRIPTION
This PR adds keyboard navigation to the main section navbar (via tabindex and a new keypress event handler)

Preview:
![nav-via-kboard](https://user-images.githubusercontent.com/1060893/31024702-ea7bb660-a50d-11e7-838f-fb57f430649c.gif)
