### PR TITLE
temporary fix for anchor links

### DIFF
--- a/DOL.WHD.Section14c.Web/package-lock.json
+++ b/DOL.WHD.Section14c.Web/package-lock.json
@@ -264,7 +264,7 @@
       "requires": {
         "moment": "2.18.1"
       }
-    },    
+    },
     "angular-resource": {
       "version": "1.6.6",
       "resolved": "https://registry.npmjs.org/angular-resource/-/angular-resource-1.6.6.tgz",
@@ -1622,6 +1622,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.2",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -7012,6 +7013,11 @@
       "resolved": "https://registry.npmjs.org/ng-mask/-/ng-mask-3.1.1.tgz",
       "integrity": "sha1-21/5roh5v3QSgNJCdcvnhhlBIao="
     },
+    "ng2-page-scroll": {
+      "version": "4.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/ng2-page-scroll/-/ng2-page-scroll-4.0.0-beta.11.tgz",
+      "integrity": "sha1-n3jagNRPNo4fTk3XcBNsYNd/rP4="
+    },
     "ngtemplate-loader": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/ngtemplate-loader/-/ngtemplate-loader-1.3.1.tgz",
@@ -7234,30 +7240,6 @@
       "dev": true,
       "requires": {
         "is": "3.2.1"
-      }
-    },
-    "nomnom": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.6.2.tgz",
-      "integrity": "sha1-hKZqJgF0QI/Ft3oY+IjszET7aXE=",
-      "dev": true,
-      "requires": {
-        "colors": "0.5.1",
-        "underscore": "1.4.4"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
-          "dev": true
-        },
-        "underscore": {
-          "version": "1.4.4",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ=",
-          "dev": true
-        }
       }
     },
     "nopt": {
@@ -8981,35 +8963,6 @@
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
       "requires": {
         "is-finite": "1.0.2"
-      }
-    },
-    "replace": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/replace/-/replace-0.3.0.tgz",
-      "integrity": "sha1-YAgXIRiGWFlatqeU63/ty0yNOcc=",
-      "dev": true,
-      "requires": {
-        "colors": "0.5.1",
-        "minimatch": "0.2.14",
-        "nomnom": "1.6.2"
-      },
-      "dependencies": {
-        "colors": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-0.5.1.tgz",
-          "integrity": "sha1-fQAj6usVTo7p/Oddy5I9DtFmd3Q=",
-          "dev": true
-        },
-        "minimatch": {
-          "version": "0.2.14",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          }
-        }
       }
     },
     "replace-ext": {

--- a/DOL.WHD.Section14c.Web/package.json
+++ b/DOL.WHD.Section14c.Web/package.json
@@ -97,6 +97,7 @@
     "lodash": "^4.16.1",
     "moment": "^2.15.2",
     "ng-mask": "^3.1.1",
+    "ng2-page-scroll": "^4.0.0-beta.11",
     "rxjs": "5.0.1",
     "systemjs": "0.19.40",
     "zone.js": "^0.8.4",

--- a/DOL.WHD.Section14c.Web/src/v4/app.module.ts
+++ b/DOL.WHD.Section14c.Web/src/v4/app.module.ts
@@ -6,11 +6,11 @@ import { DolFooterComponent } from './dol-footer.component';
 import { DolHeaderComponent } from './dol-header.component';
 import { HelloWorldComponent } from './hello-world.component';
 import { UiLibraryComponent } from './ui-library.component';
-
+import {Ng2PageScrollModule} from 'ng2-page-scroll';
 import { mainTopNavDirective } from '../modules/components/mainTopNavControl/mainTopNav.component';
 
 @NgModule({
-  imports: [BrowserModule, UpgradeModule],
+  imports: [BrowserModule, UpgradeModule, Ng2PageScrollModule],
   declarations: [
     DolFooterComponent,
     DolHeaderComponent,

--- a/DOL.WHD.Section14c.Web/src/v4/dol-header.component.ts
+++ b/DOL.WHD.Section14c.Web/src/v4/dol-header.component.ts
@@ -4,7 +4,7 @@ import { Component } from '@angular/core';
   selector: 'dol-header',
   styleUrls: ['./dol-header.component.css'],
   template: `
-    <a href="#mainContent" class="dol-skip-to-main">skip to main content</a>
+    <a pageScroll href="#mainContent" class="dol-skip-to-main">skip to main content</a>
     <header class="dol-header" role="header">
       <a class="brand" href="/">
         <img


### PR DESCRIPTION
#### What's this PR do?
- Allows anchor links to sections within the same page
- Fixes Skip To Main Content link
#### Where should the reviewer start?
#### How should this be manually tested?
- Open app in browser without debug tools, click the address bar and hit "Tab". A "skip to main content" button should appear. Click the button and verify that the page scrolls to "mainContent
 div
#### Any background context you want to provide?
- I think this should be a temporary fix. From my investigation, Angular 4 doesn’t support anchor links all that well out of the box -- at least not intuitively (see https://github.com/angular/angular/issues/6595). I found several forum threads and discussions surrounding this issue that offer potential fixes that only involve refactoring the code without adding any additional npm packages. However, none of those fixes worked for me. I think that is because of how we have setup the AngularJS and Angular (4) combination in our app. I can definitely refactor the code so that the header component where the “Skip to main content” link lives is an AngularJS component/directive instead of an Angular4 one – this would be working against our efforts to eventually switch to Angular 4 so I only want to use it as a last resort. The pure fixes that I mentioned previously involve an Angular4 component in an app that uses Angular4 routing. We are not currently using Angular4 routing in our app. I believe that in order to keep the header an Angular4 component and still fix the “Skip To Main Content” link to scroll to a section within the same page, we will need to do a broader refactoring of the routing and current application setup from a front-end perspective.
 
The fix that this pull request implements was quick and easy but might not work well on IE browsers. We may want to reopen the user story related to integrating Angular4 alongside AngularJS.


#### What are the relevant tickets?
#307 
#### Screenshots (if appropriate)
#### Questions:
