### PR TITLE
temporary fix for self signed certs for IE 11

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/services/authService.js
+++ b/DOL.WHD.Section14c.Web/src/modules/services/authService.js
@@ -14,36 +14,40 @@ module.exports = function(ngModule) {
     this.userLogin = function(email, password) {
       const self = this;
       const url = _env.api_url + '/Token';
+      const mockUrl = _env.api_url + '/'; // Temporary fix for IE 11
       const d = $q.defer();
-
       $http({
-        method: 'POST',
-        url: url,
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        data: $.param({
-          grant_type: 'password',
-          userName: email,
-          password: password
-        })
-      }).then(
-        function successCallback(result) {
-          const data = result.data;
-          stateService.access_token = data.access_token;
-          self.authenticateUser().then(
-            function() {
-              d.resolve();
-            },
-            function(error) {
-              d.reject(error);
-            }
-          );
-        },
-        function errorCallback(error) {
-          //console.log(error);
-          d.reject(error);
-        }
-      );
-
+        method: 'GET',
+        url: mockUrl
+      }).then(function(){
+        $http({
+          method: 'POST',
+          url: url,
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          data: $.param({
+            grant_type: 'password',
+            userName: email,
+            password: password
+          })
+        }).then(
+          function successCallback(result) {
+            const data = result.data;
+            stateService.access_token = data.access_token;
+            self.authenticateUser().then(
+              function() {
+                d.resolve();
+              },
+              function(error) {
+                d.reject(error);
+              }
+            );
+          },
+          function errorCallback(error) {
+            //console.log(error);
+            d.reject(error);
+          }
+        );
+      })
       return d.promise;
     };
 


### PR DESCRIPTION
#### What's this PR do?
Temporary fix for IE 11 compatibility with self-signed certs related to the error: 

SCRIPT7002: XMLHttpRequest: Network Error 0x2ef3, Could not complete the operation due to error 00002ef3 

#### Any background context you want to provide?
Apparently this is a bug with IE. See the links below:
- https://stackoverflow.com/questions/23145688/ie10-11-ajax-xhr-error-script7002-xmlhttprequest-network-error-0x2ef3/32106649#32106649
- https://stackoverflow.com/questions/16312938/ie10-ie11-abort-post-ajax-request-after-clearing-cache-with-error-network-error/16818527#16818527
- http://jonnyreeves.co.uk/2013/making-xhr-request-to-https-domains-with-winjs/

This issue will probably go away when we start using real certificates. In the meantime we should look into setting up our servers to trust the self-signed certificate
 
#### What are the relevant tickets?
#### Screenshots (if appropriate)
#### Questions:
- Should we open up another user story or issue for this?