### PR TITLE
make capitalization of "Employers" consistent

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/components/userRegistrationForm/userRegistrationFormTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/userRegistrationForm/userRegistrationFormTemplate.html
@@ -3,7 +3,7 @@
     <p>We are now accepting Section 14(c) Certificate Applications electronically.</p>
     <ul>
       <li>
-        All employers, including current Certificate Holders, previous
+        All Employers, including current Certificate Holders, previous
         Certificate Holders, and new applicants, will have to create an
         account in order to submit the form electronically.
       </li>


### PR DESCRIPTION
Fix capitalization of "Employers" in one place to make this consistent across this section.
