### PR TITLE
change "Registration" to "registration"

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/components/userRegistrationForm/userRegistrationFormTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/userRegistrationForm/userRegistrationFormTemplate.html
@@ -46,7 +46,7 @@
     </div>
     <div class="usa-alert usa-alert-info" ng-show="vm.showEinHelp">
       <div class="usa-alert-body">
-        <p class="usa-alert-text">Providing the EIN at Registration helps us ensure there is only one account per Employer.</p>
+        <p class="usa-alert-text">Providing the EIN at registration helps us ensure there is only one account per Employer.</p>
         <p>Additional users can be added once the Employer is registered.</p>
       </div>
     </div>


### PR DESCRIPTION
Unless we typically capitalize "registration", this PR changes this capitalization to make the text easier for users to parse.
