### PR TITLE
Added keyboard functionality for the 'Show Help for All Items' Link

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionAppInfo/sectionAppInfoTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionAppInfo/sectionAppInfoTemplate.html
@@ -3,7 +3,7 @@
 
   <div class="dol-form-section-help">
     <ul>
-      <li><a role="button" ng-keyup="$event.keyCode == 13 ? vm.toggleAllHelpText() : null" ng-click="vm.toggleAllHelpText()" tabindex="0">Show Help for All Items</a></li>
+      <li><a role="button" ng-keyup="$event.keyCode === 13 ? vm.toggleAllHelpText() : null" ng-click="vm.toggleAllHelpText()" tabindex="0">Show Help for All Items</a></li>
     </ul>
   </div>
 </div>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionAppInfo/sectionAppInfoTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionAppInfo/sectionAppInfoTemplate.html
@@ -3,7 +3,7 @@
 
   <div class="dol-form-section-help">
     <ul>
-      <li><a role="button" ng-click="vm.toggleAllHelpText()" tabindex="0">Show Help for All Items</a></li>
+      <li><a role="button" ng-keyup="$event.keyCode == 13 ? vm.toggleAllHelpText() : null" ng-click="vm.toggleAllHelpText()" tabindex="0">Show Help for All Items</a></li>
     </ul>
   </div>
 </div>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionWioa/sectionWioaTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionWioa/sectionWioaTemplate.html
@@ -3,7 +3,7 @@
 
   <div class="dol-form-section-help">
     <ul>
-      <li><a role="button" ng-keyup="$event.keyCode == 13 ? vm.toggleAllHelpText() : null" ng-click="vm.toggleAllHelpText()" tabindex="0">Show Help for All Items</a></li>
+      <li><a role="button" ng-keyup="$event.keyCode === 13 ? vm.toggleAllHelpText() : null" ng-click="vm.toggleAllHelpText()" tabindex="0">Show Help for All Items</a></li>
     </ul>
   </div>
 </div>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionWioa/sectionWioaTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionWioa/sectionWioaTemplate.html
@@ -3,7 +3,7 @@
 
   <div class="dol-form-section-help">
     <ul>
-      <li><a role="button" ng-click="vm.toggleAllHelpText()" tabindex="0">Show Help for All Items</a></li>
+      <li><a role="button" ng-keyup="$event.keyCode == 13 ? vm.toggleAllHelpText() : null" ng-click="vm.toggleAllHelpText()" tabindex="0">Show Help for All Items</a></li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
#### What's this PR do?

Per Michelle's review of #287 and #298, the 'Show Help for All Items' link needs to be keyboard accessible. This PR adds the ability to press the Enter key to trigger the function on this link. 
