### PR TITLE
Update alt text for DOL logo

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/components/dolHeader/dolHeaderTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/dolHeader/dolHeaderTemplate.html
@@ -4,7 +4,7 @@
     <img
       class="brand--img"
       src="/images/dol-logo.png"
-      alt="Seal of the United States Department of Labor"
+      alt="United States Department of Labor"
       width="70"
       height="70"
     />

--- a/DOL.WHD.Section14c.Web/src/v4/dol-footer.component.ts
+++ b/DOL.WHD.Section14c.Web/src/v4/dol-footer.component.ts
@@ -10,7 +10,7 @@ import { Component } from '@angular/core';
           <img
             class="brand--img"
             src="images/dol-logo-white.png"
-            alt="Seal of the United States Department of Labor"
+            alt="United States Department of Labor"
             width="70"
             height="70"
           />


### PR DESCRIPTION
#287 and #298: 
Per Michelle's review comment, updated the alt text for the DOL logo from "Seal of the United States Department of Labor" to "United States Department of Labor".