### PR TITLE
Wage Data Tabs Accessibility

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionEmployer/sectionEmployerTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionEmployer/sectionEmployerTemplate.html
@@ -3,7 +3,7 @@
 
   <div class="dol-form-section-help">
     <ul>
-      <li><a role="button" ng-click="vm.toggleAllHelpText()" tabindex="0">Show Help for All Items</a></li>
+      <li><a role="button" ng-keyup="$event.keyCode === 13 ? vm.toggleAllHelpText() : null" ng-click="vm.toggleAllHelpText()" tabindex="0">Show Help for All Items</a></li>
     </ul>
   </div>
 </div>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/sectionWageDataController.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/sectionWageDataController.js
@@ -4,6 +4,7 @@ module.exports = function(ngModule) {
   ngModule.controller('sectionWageDataController', function(
     $scope,
     $location,
+    $document,
     stateService,
     navService,
     responsesService,
@@ -55,6 +56,14 @@ module.exports = function(ngModule) {
         );
       } else {
         navService.clearNextQuery();
+      }
+    };
+
+    vm.tabPanelFocus = function(id) {
+      if (id === 1) {
+          $document[0].getElementById('hourlyTabPanel').focus();
+      } else {
+          $document[0].getElementById('pieceRateTabPanel').focus();
       }
     };
 

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/sectionWageDataTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/sectionWageDataTemplate.html
@@ -3,8 +3,8 @@
 
   <div class="dol-form-section-help">
     <ul>
-      <li><a href="" ng-click="vm.toggleAllHelpText()">Show Help for All Items</a></li>
-      <li><a href="" ng-click="vm.showLinks = !vm.showLinks">Helpful Links</a></li>
+      <li><a href="" role="button" ng-keyup="$event.keyCode === 13 ? vm.toggleAllHelpText() : null" ng-click="vm.toggleAllHelpText()" tabindex="0">Show Help for All Items</a></li>
+      <li><a href="" role="button" ng-click="vm.showLinks = !vm.showLinks" tabindex="0">Helpful Links</a></li>
     </ul>
   </div>
 </div>
@@ -26,17 +26,17 @@
         </ul>
     </fieldset>
   </div>
-
+ 
   <div id="wagedata_tab_box" class="form-tabbed-section" ng-show="formData.payTypeId === 23">
-    <a href class="form-tab {{ vm.activeTab === 1 ? 'active' : '' }}" aria-selected="{{ vm.activeTab === 1 ? 'true' : 'false' }}" ng-click="vm.onTabClick(1)" ng-keyup="vm.onTabClick(1)">
+    <a href class="form-tab {{ vm.activeTab === 1 ? 'active' : '' }}" aria-selected="{{ vm.activeTab === 1 ? 'true' : 'false' }}" ng-click="vm.onTabClick(1)" ng-keyup="$event.keyCode === 13 ? vm.tabPanelFocus(1) : vm.onTabClick(1)">
       Hourly
     </a>
-    <a href class="form-tab {{ vm.activeTab === 2 ? 'active' : '' }}" aria-selected="{{ vm.activeTab === 2 ? 'true' : 'false' }}" ng-click="vm.onTabClick(2)" ng-keyup="vm.onTabClick(2)">
+    <a href class="form-tab {{ vm.activeTab === 2 ? 'active' : '' }}" aria-selected="{{ vm.activeTab === 2 ? 'true' : 'false' }}" ng-click="vm.onTabClick(2)" ng-keyup="$event.keyCode === 13 ? vm.tabPanelFocus(2) : vm.onTabClick(2)">
       Piece Rate
     </a>
   </div>
-  <wage-data-pay-type-form id="hourlyTabPanel" show-all-help="vm.showAllHelp" paytype="hourly" ng-show="formData.payTypeId === 21 || (formData.payTypeId === 23 && vm.activeTab !== 2)"></wage-data-pay-type-form>
-  <wage-data-pay-type-form id="pieceRateTabPanel" show-all-help="vm.showAllHelp" paytype="piecerate" ng-show="formData.payTypeId === 22 || (formData.payTypeId === 23 && vm.activeTab === 2)"></wage-data-pay-type-form>
+  <wage-data-pay-type-form paytype="hourly" ng-show="formData.payTypeId === 21 || (formData.payTypeId === 23 && vm.activeTab !== 2)"></wage-data-pay-type-form>
+  <wage-data-pay-type-form paytype="piecerate" ng-show="formData.payTypeId === 22 || (formData.payTypeId === 23 && vm.activeTab === 2)"></wage-data-pay-type-form>
 </div>
 <div class="form-sidebar">
   <div class="links-block" ng-show="vm.showLinks === true">

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/wageDataPayTypeFormTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/wageDataPayTypeFormTemplate.html
@@ -6,7 +6,7 @@
     </div>
     <helptext id="numWorkersHelp">Count the total number of workers paid {{ paytype === 'an hourly' ? 'hourly' : 'a piece rate'}} subminimum wage rate at any time during the most recently completed fiscalquarter that ended on the date listed in Item 7(a).</helptext>
     <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.numWorkers')">{{ validate(modelPrefix() + '.numWorkers') }}</span>
-    <input id="numWorkers" name="numWorkers" aria-describedby="numWorkersHelp" type="number" class="numeric7" min="0" step="1" ng-model="formData[modelPrefix()].numWorkers">
+    <input id="numWorkers" name="numWorkers" type="number" class="numeric7" min="0" step="1" ng-model="formData[modelPrefix()].numWorkers">
   </div>
 
   <fieldset class="dol-form-question-block">
@@ -19,7 +19,7 @@
       <helptext id="jobNameHelp">Identify the job or contract and provide a brief description of the work performed by workers paid subminimum wages (e.g., Name: Kitchen cleaning, Description: sink, counters, stove, refrigerator, microwave cleaning duties, or Name: Contract No. 123-456 with Sheets Inc., Description: Laundry Service).</helptext>
       <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.jobName')">{{ validate(modelPrefix() + '.jobName') }}</span>
       <label for="jobName">Name of Job or Contract</label>
-      <input id="jobName" name="jobName" aria-describedby="jobNameHelp" type="text" ng-model="formData[modelPrefix()].jobName">
+      <input id="jobName" name="jobName" type="text" ng-model="formData[modelPrefix()].jobName">
     </div>
 
     <div class="dol-form-question-block" ng-class="validate(modelPrefix() + '.jobDescription') ? 'usa-input-error' : ''">
@@ -42,7 +42,7 @@
       <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.prevailingWageMethod')">{{ validate(modelPrefix() + '.prevailingWageMethod') }}</span>
       <ul class="usa-unstyled-list">
         <li ng-repeat="response in responses.PrevailingWageMethod">
-          <input id="wagemethod_{{ response.id }}" type="radio" name="wage-method" aria-describedby="wageMethodHelp" ng-value="response.id" ng-model="formData[modelPrefix()].prevailingWageMethodId">
+          <input id="wagemethod_{{ response.id }}" type="radio" name="wage-method" ng-value="response.id" ng-model="formData[modelPrefix()].prevailingWageMethodId">
           <label for="wagemethod_{{ response.id }}">{{ response.display }}</label>
         </li>
       </ul>
@@ -73,7 +73,7 @@
           <div ng-class="vm.validateActiveSourceEmployerProperty('employerName') ? 'usa-input-error' : ''">
             <label for="sourceEmployerName">Source Employer Name</label>
             <span class="usa-input-error-message" role="alert" ng-show="vm.validateActiveSourceEmployerProperty('employerName')">{{ vm.validateActiveSourceEmployerProperty('employerName') }}</span>
-            <input id="sourceEmployerName" name="sourceEmployerName" aria-describedby="sourceEmployerNameHelp" type="text" ng-model="vm.activeSourceEmployer.employerName">
+            <input id="sourceEmployerName" name="sourceEmployerName" type="text" ng-model="vm.activeSourceEmployer.employerName">
           </div>
 
           <div class="usa-form-large">
@@ -270,7 +270,7 @@
         <div ng-class="validate(modelPrefix() + '.alternateWageData.alternateWorkDescription') ? 'usa-input-error' : ''">
           <label for="alternateWorkDescription">Description of Work (include job classification code, if known)</label>
           <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.alternateWageData.alternateWorkDescription')">{{ validate(modelPrefix() + '.alternateWageData.alternateWorkDescription') }}</span>
-          <textarea id="alternateWorkDescription" name="alternateWorkDescription" aria-describedby="alternateWorkDescriptionHelp" ng-model="formData[modelPrefix()].alternateWageData.alternateWorkDescription"></textarea>
+          <textarea id="alternateWorkDescription" name="alternateWorkDescription" ng-model="formData[modelPrefix()].alternateWageData.alternateWorkDescription"></textarea>
         </div>
 
         <div ng-class="validate(modelPrefix() + '.alternateWageData.alternateDataSourceUsed') ? 'usa-input-error' : ''">
@@ -322,7 +322,7 @@
       </div>
       <helptext id="workMeasurementFrequencyHelp">Indicate how frequently the employer conducts work measurements or time studies of each worker with a disability who is paid anhourly subminimum wage.</helptext>      
       <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.workMeasurementFrequency')">{{ validate(modelPrefix() + '.workMeasurementFrequency') }}</span>
-      <input id="workMeasurementFrequency" name="workMeasurementFrequency" aria-describedby="workMeasurementFrequencyHelp" type="text" ng-model="formData[modelPrefix()].workMeasurementFrequency">
+      <input id="workMeasurementFrequency" name="workMeasurementFrequency" type="text" ng-model="formData[modelPrefix()].workMeasurementFrequency">
     </div>
 
     <div class="dol-form-question-block" ng-class="validate(modelPrefix() + '.attachmentId') ? 'usa-input-error' : ''">
@@ -355,7 +355,7 @@
           <div ng-class="validate(modelPrefix() + '.pieceRateWorkDescription') ? 'usa-input-error' : ''">
             <label for="pieceRateWorkDescription">Descripton of Work</label>
             <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.pieceRateWorkDescription')">{{ validate(modelPrefix() + '.pieceRateWorkDescription') }}</span>
-            <input id="pieceRateWorkDescription" name="pieceRateWorkDescription" aria-describedby="pieceRateWorkDescriptionHelp" type="text" ng-model="formData[modelPrefix()].pieceRateWorkDescription">
+            <input id="pieceRateWorkDescription" name="pieceRateWorkDescription" type="text" ng-model="formData[modelPrefix()].pieceRateWorkDescription">
           </div>
           <div ng-class="validate(modelPrefix() + '.prevailingWageDeterminedForJob') ? 'usa-input-error' : ''">
             <label for="prevailingWageDeterminedForJob">Prevailing Wage Determined for This Job</label>

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/wageDataPayTypeFormTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionWageData/wageDataPayTypeFormTemplate.html
@@ -2,9 +2,10 @@
   <div class="dol-form-question-block" ng-class="validate(modelPrefix() + '.numWorkers') ? 'usa-input-error' : ''">
     <div class="dol-form-question-help">
       <label for="numWorkers" class="dol-form-question-text" id="numWorkersLabel">{{ paytype === 'hourly' ? 'How many workers with disabilities were paid an hourly subminimum wage during the most recently completed fiscal quarter?' : 'How many workers with disabilities received subminimum wages and were paid piece rates during the most recently completed fiscal quarter?' }}</label>
-      <helplink aria-controls="numWorkersHelp" aria-describedby="numWorkersLabel"></helplink>     
+      <!-- The first tabbable element has the ID for tab panel focus. -->
+      <helplink id="{{ paytype === 'hourly' ? 'hourlyTabPanel' : 'pieceRateTabPanel'}}" aria-controls="numWorkersHelp" aria-describedby="numWorkersLabel"></helplink>     
     </div>
-    <helptext id="numWorkersHelp">Count the total number of workers paid {{ paytype === 'an hourly' ? 'hourly' : 'a piece rate'}} subminimum wage rate at any time during the most recently completed fiscalquarter that ended on the date listed in Item 7(a).</helptext>
+    <helptext id="numWorkersHelp">Count the total number of workers paid {{ paytype === 'hourly' ? 'an hourly' : 'a piece rate'}} subminimum wage rate at any time during the most recently completed fiscalquarter that ended on the date listed in Item 7(a).</helptext>
     <span class="usa-input-error-message" role="alert" ng-show="validate(modelPrefix() + '.numWorkers')">{{ validate(modelPrefix() + '.numWorkers') }}</span>
     <input id="numWorkers" name="numWorkers" type="number" class="numeric7" min="0" step="1" ng-model="formData[modelPrefix()].numWorkers">
   </div>
@@ -394,3 +395,4 @@
     </div>
   </div>
 </div>
+<h3 id="textAnchor">This is a test anchor.</h3>


### PR DESCRIPTION
#### What's this PR do?

#294 Adds keyboard accessibility to the Hourly/Piece Rate tabs in Wage Data page. The user can move focus from a tab to the corresponding tab panel with the Enter key. Focus moves to the first interactive element in the tab panel.

Removed aria-describedby from input fields if they were described by help text. (Help text is accessible by help button.) Use the aria-describedby on input fields if the descriptive text is an example or unit.

#296 Added keyboard accessibility to the "Show Help for All Items" link on Employer page.
