### PR TITLE
Add more tests to cover PDF API PdfHelper

### DIFF
--- a/DOL.WHD.Section14c.PdfAPi/PdfHelper/PdfHelper.cs
+++ b/DOL.WHD.Section14c.PdfAPi/PdfHelper/PdfHelper.cs
@@ -41,7 +41,7 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper
                     AddPagesToPdf(ref outputDocument, doc);
                 }
 
-                if (applicationData.Type.ToLower().Contains("html"))
+                if (applicationData.Type.ToLower().Contains("html") && !String.IsNullOrEmpty(applicationData.HtmlString))
                 {
                     var doc = GetPdfDocFromHtml(outputDocument, applicationData.HtmlString);
                     AddPagesToPdf(ref outputDocument, doc);

--- a/DOL.WHD.Section14c.PdfAPi/PdfHelper/PdfHelper.cs
+++ b/DOL.WHD.Section14c.PdfAPi/PdfHelper/PdfHelper.cs
@@ -48,7 +48,7 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper
                 }
             }
 
-            if (applicationData?.FilePaths != null)
+            if (applicationData.FilePaths != null)
             {
                 outputDocument = ConcatenatePDFDocumentByPath(outputDocument, applicationData.FilePaths);
             }

--- a/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
+++ b/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using DOL.WHD.Section14c.PdfApi.PdfHelper;
 using System;
 using System.Collections.Generic;
@@ -110,6 +110,17 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
             {
                 Buffer = null,
                 Type = "image",
+            };
+            PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
+        }
+
+        [TestMethod()]
+        [ExpectedException(typeof(ArgumentException))]
+        public void PdfHelper_ThrowsExceptionOnEmptyilePath()
+        {
+            PDFContentData contentData = new PDFContentData
+            {
+                FilePaths = new List<string> { "" }
             };
             PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
         }

--- a/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
+++ b/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
@@ -34,7 +34,7 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
         }
 
         [TestMethod()]
-        public void TestPdfByteArrayToPDF()
+        public void PdfHelper_CanConcatenatePDFFromBytes()
         {
             PDFContentData contentData = new PDFContentData {
                 Buffer = testPdfByteArray,
@@ -45,7 +45,7 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
         }
 
         [TestMethod()]
-        public void TestImageByteArrayToPdf()
+        public void PdfHelper_CanConcatenateImageFromBytes()
         {
             PDFContentData contentData = new PDFContentData
             {
@@ -57,7 +57,7 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
         }
 
         [TestMethod()]
-        public void TestHtmlToPdf()
+        public void PdfHelper_CanConcatenateHTMLFromString()
         {
             PDFContentData contentData = new PDFContentData
             {

--- a/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
+++ b/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
@@ -45,12 +45,34 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
         }
 
         [TestMethod()]
+        public void PdfHelper_CanConcatenatePDFFromFile()
+        {
+            PDFContentData contentData = new PDFContentData
+            {
+                FilePaths = new List<string> { testPdfPath }
+            };
+            PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
+            Assert.IsNotNull(doc);
+        }
+
+        [TestMethod()]
         public void PdfHelper_CanConcatenateImageFromBytes()
         {
             PDFContentData contentData = new PDFContentData
             {
                 Buffer = testImageByteArray,
                 Type = "image",
+            };
+            PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
+            Assert.IsNotNull(doc);
+        }
+
+        [TestMethod()]
+        public void PdfHelper_CanConcatenateImageFromFile()
+        {
+            PDFContentData contentData = new PDFContentData
+            {
+                FilePaths = new List<string> { testImagePath }
             };
             PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
             Assert.IsNotNull(doc);

--- a/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
+++ b/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
@@ -120,7 +120,7 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
             PDFContentData contentData = new PDFContentData
             {
                 HtmlString = testHtmlString,
-                Type = "",
+                Type = "html",
             };
             PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
             Assert.IsNotNull(doc);

--- a/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
+++ b/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
@@ -116,7 +116,7 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
 
         [TestMethod()]
         [ExpectedException(typeof(ArgumentException))]
-        public void PdfHelper_ThrowsExceptionOnEmptyilePath()
+        public void PdfHelper_ThrowsExceptionOnEmptyFilePath()
         {
             PDFContentData contentData = new PDFContentData
             {

--- a/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
+++ b/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
@@ -24,7 +24,7 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
         public void Initialize()
         {
             testHtmlString = @"<html><body><h1>My Content</h1><p>My Content.</p><a href='#'></a></body></html>";
-            string testFilePath = Path.GetFullPath(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, @"..\..\TestFiles"));
+            string testFilePath = Path.GetFullPath(Path.Combine(System.Reflection.Assembly.GetExecutingAssembly().Location, @"..\..\..\TestFiles"));
             testPdfPath = Path.Combine(testFilePath, "TestFile1.pdf");
             testImagePath = Path.Combine(testFilePath, "TestImage.jpg");
 
@@ -39,7 +39,7 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
             PDFContentData contentData = new PDFContentData {
                 Buffer = testPdfByteArray,
                 Type = "pdf",
-            };            
+            };
             PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
             Assert.IsNotNull(doc);
         }

--- a/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
+++ b/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
@@ -115,6 +115,17 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
         }
 
         [TestMethod()]
+        [ExpectedException(typeof(FileNotFoundException))]
+        public void PdfHelper_ThrowsExceptionOnNonexistantFilePath()
+        {
+            PDFContentData contentData = new PDFContentData
+            {
+                FilePaths = new List<string> { @"C:\this-is-a-fake-file-and-i-really-hope-nobody-really-has-one-of-these.pdf" }
+            };
+            PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
+        }
+
+        [TestMethod()]
         public void PdfHelper_GracefullyHandlesUnsupportedFileType()
         {
             PDFContentData contentData = new PDFContentData

--- a/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
+++ b/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
@@ -89,5 +89,41 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
             PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
             Assert.IsNotNull(doc);
         }
+
+        [TestMethod()]
+        [ExpectedException(typeof(ArgumentException))]
+        public void PdfHelper_ThrowsExceptionOnEmptyPDFBytes()
+        {
+            PDFContentData contentData = new PDFContentData
+            {
+                Buffer = null,
+                Type = "pdf",
+            };
+            PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
+        }
+
+        [TestMethod()]
+        [ExpectedException(typeof(ArgumentException))]
+        public void PdfHelper_ThrowsExceptionOnEmptyImageBytes()
+        {
+            PDFContentData contentData = new PDFContentData
+            {
+                Buffer = null,
+                Type = "image",
+            };
+            PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
+        }
+
+        [TestMethod()]
+        public void PdfHelper_GracefullyHandlesEmptyHTMLString()
+        {
+            PDFContentData contentData = new PDFContentData
+            {
+                HtmlString = testHtmlString,
+                Type = "",
+            };
+            PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
+            Assert.IsNotNull(doc);
+        }
     }
 }

--- a/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
+++ b/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
@@ -119,7 +119,7 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
         {
             PDFContentData contentData = new PDFContentData
             {
-                HtmlString = testHtmlString,
+                HtmlString = "",
                 Type = "html",
             };
             PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);

--- a/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
+++ b/DOL.WHD.Section14c.Test/PdfHelper/PdfHelperTests.cs
@@ -115,6 +115,17 @@ namespace DOL.WHD.Section14c.PdfApi.PdfHelper.Tests
         }
 
         [TestMethod()]
+        public void PdfHelper_GracefullyHandlesUnsupportedFileType()
+        {
+            PDFContentData contentData = new PDFContentData
+            {
+                FilePaths = new List<string> { "fake-file.xls" }
+            };
+            PdfDocument doc = PdfHelper.ConcatenatePDFs(outputDocument, contentData);
+            Assert.IsNotNull(doc);
+        }
+
+        [TestMethod()]
         public void PdfHelper_GracefullyHandlesEmptyHTMLString()
         {
             PDFContentData contentData = new PDFContentData


### PR DESCRIPTION
#### What's this PR do?

Adds some more tests to cover the PdfHelper class.  Also makes a change to the way the test file paths are computed.  Using `AppDomain.CurrentDomain.BaseDirectory` works great inside Visual Studio, but it was throwing an exception when the tests were run by TestRunner, which was causing a lot of the tests to silently fail.  (The output of TestRunner is pretty tough to read.)  That further led to a slight decrease in code coverage.

There are a couple of changes to PdfHelper itself as well:
1. for concatenating HTML strings, it now checks that the string is non-empty right at the beginning.  The reason is that if the string was empty, the `GetPdfDocFromHtml` on line 46 would work fine, but the `AddPagesToPdf` call on 47 would fail because the generated document was empty.  It would complain that it couldn't save a PDF with no pages.
2. removed the null conditional when checking `applicationData.FilePaths` on line 51 - there are prior attempts to access `applicationData`, so it can't be null at this point.  It was impossible to get full branch coverage as a result, plus it was an unnecessary check

#### Where should the reviewer start?

Pull the code, run the tests in Visual Studio, then run the coverage script.  Verify that all the tests pass and check the coverage on the `DOL.WHD.Section14c.PdfApi.PdfHelper.PdfHelper` class.  (It should be 100% line coverage, high 90% branch coverage - there's one untestable branch, on a redundant `String.IsNullOrEmpty` check).

Check the tests to make sure they setup and execute correctly and make the correct assertions.