### PR TITLE
Miscellaneous a11y fixes as noted by Employer Page a11y review

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/components/anchorLink/anchorLinkDirective.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/anchorLink/anchorLinkDirective.js
@@ -13,8 +13,11 @@ module.exports = function(ngModule) {
           $document[0].getElementById(attr.scrollto).focus();
         });
         element.bind('keydown keypress', function() {
-          $anchorScroll(attr.scrollto);
-          $document[0].getElementById(attr.scrollto).focus();
+          if (event.which === 13) {
+            $anchorScroll(attr.scrollto);
+            $document[0].getElementById(attr.scrollto).focus();
+            event.preventDefault();
+          }  
         });
       },
       transclude: true

--- a/DOL.WHD.Section14c.Web/src/modules/components/attachmentField/attachmentFieldDirective.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/attachmentField/attachmentFieldDirective.js
@@ -10,7 +10,8 @@ module.exports = function(ngModule) {
       controller: 'attachmentFieldController',
       scope: {
         attachmentId: '=',
-        attachmentName: '='
+        attachmentName: '=',
+        inputId: '@'
       },
       controllerAs: 'vm'
     };

--- a/DOL.WHD.Section14c.Web/src/modules/components/attachmentField/attachmentFieldTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/attachmentField/attachmentFieldTemplate.html
@@ -1,10 +1,10 @@
 <div ng-show="attachmentId == undefined">
   <div class="dol-file-upload-ui">
     <div aria-hidden="true" class="usa-button-primary">Browse</div>
-    <input class="dol-file-upload-input" id="{{::$id}}_FileUpload" class="upload-file-input" type="file" onchange="angular.element(this).scope().vm.onAttachmentSelected(this)" accept=".doc,.docx,.xls,.xlsx,.pdf,.jpg,.jpeg,.png">
+    <input class="dol-file-upload-input" id="{{inputId}}" class="upload-file-input" type="file"  aria-describedby="fileUploadDesc_{{::$id}}" onchange="angular.element(this).scope().vm.onAttachmentSelected(this)" accept=".doc,.docx,.xls,.xlsx,.pdf,.jpg,.jpeg,.png">
     <div class="dol-file-upload-focus"></div>
   </div>  
-  <p class="underlabel" id="{{::$id}}_Description">File types accepted: PDF, Word, Excel, JPG, PNG</p>
+  <p class="underlabel" id="fileUploadDesc_{{::$id}}">File types accepted: PDF, Word, Excel, JPG, PNG</p>
 </div>
 <div ng-if="attachmentId != undefined">
   <a ng-href="{{vm.apiService.attachmentApiURL}}{{vm.stateService.ein}}/{{attachmentId}}?access_token={{vm.stateService.access_token}}" id="{{attachmentId}}">

--- a/DOL.WHD.Section14c.Web/src/modules/components/dateField/dateFieldTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/dateField/dateFieldTemplate.html
@@ -1,20 +1,20 @@
 <div class="usa-date-of-birth dol-side-example">
   <div class="usa-form-group usa-form-group-month">
-    <label for="{{::$id}}_Month">Month</label>
-    <input class="usa-input-inline" aria-describedby="{{::$id}}_dateExample {{::$id}}_dateExampleMonth" class="usa-form-control" id="{{::$id}}_Month" name="{{::$id}}_Month" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="" ng-model="vm.month">
+    <label for="Month_{{::$id}}">Month</label>
+    <input class="usa-input-inline" aria-describedby="dateExample_{{::$id}} dateExampleMonth_{{::$id}}" class="usa-form-control" id="Month_{{::$id}}" name="Month_{{::$id}}" pattern="0?[1-9]|1[012]" type="number" min="1" max="12" value="" ng-model="vm.month">
   </div>
   <div class="usa-form-group usa-form-group-day">
-    <label for="{{::$id}}_Day">Day</label>
-    <input class="usa-input-inline" aria-describedby="{{::$id}}_dateExample {{::$id}}_dateExampleDay" class="usa-form-control" id="{{::$id}}_Day" name="{{::$id}}_Day" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="" ng-model="vm.day">
+    <label for="Day_{{::$id}}">Day</label>
+    <input class="usa-input-inline" aria-describedby="dateExample_{{::$id}} dateExampleDay_{{::$id}}" class="usa-form-control" id="Day_{{::$id}}" name="Day_{{::$id}}" pattern="0?[1-9]|1[0-9]|2[0-9]|3[01]" type="number" min="1" max="31" value="" ng-model="vm.day">
   </div>
   <div class="usa-form-group usa-form-group-year">
-    <label for="{{::$id}}_Year">Year</label>
-    <input class="usa-input-inline" aria-describedby="{{::$id}}_dateExample {{::$id}}_dateExampleYear" class="usa-form-control" id="{{::$id}}_Year" name="{{::$id}}_Year" pattern="[0-9]{4}" type="number" min="1900" max="3000" value="" ng-model="vm.year">
+    <label for="Year_{{::$id}}">Year</label>
+    <input class="usa-input-inline" aria-describedby="dateExample_{{::$id}} dateExampleYear_{{::$id}}" class="usa-form-control" id="Year_{{::$id}}" name="Year_{{::$id}}" pattern="[0-9]{4}" type="number" min="1900" max="3000" value="" ng-model="vm.year">
   </div>
 </div>
-<div class="dol-example-text"><span id="{{::$id}}_dateExample">Example: </span>
-    <span id="{{::$id}}_dateExampleMonth">04</span> 
-    <span id="{{::$id}}_dateExampleDay">30</span> 
-    <span id="{{::$id}}_dateExampleYear">2016</span> 
+<div class="dol-example-text"><span id="dateExample_{{::$id}}">Example: </span>
+    <span id="dateExampleMonth_{{::$id}}">04</span> 
+    <span id="dateExampleDay_{{::$id}}">30</span> 
+    <span id="dateExampleYear_{{::$id}}">2016</span> 
 </div>
 

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionEmployer/sectionEmployerTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionEmployer/sectionEmployerTemplate.html
@@ -387,9 +387,9 @@
           </div>
         </div>
         <div ng-class="validate('employer.SCAAttachment') ? 'usa-input-error' : ''">
-          <label>Attach copies of all current SCA Wage Determinations for those contracts on which workers with disabilities are employed and earning subminimum wage.</label>
+          <label for="fileUploadSCA">Attach copies of all current SCA Wage Determinations for those contracts on which workers with disabilities are employed and earning subminimum wage.</label>
           <span class="usa-input-error-message" role="alert" ng-show="validate('employer.scaAttachmentId')">{{ validate('employer.SCAAttachment') }}</span>
-          <attachment-field attachment-id="formData.employer.scaAttachmentId" attachment-name="formData.employer.scaAttachmentName" />
+          <attachment-field input-id="fileUploadSCA" attachment-id="formData.employer.scaAttachmentId" attachment-name="formData.employer.scaAttachmentName" />
         </div>
       </div>
     </div>

--- a/DOL.WHD.Section14c.Web/src/styles/layout.scss
+++ b/DOL.WHD.Section14c.Web/src/styles/layout.scss
@@ -12,6 +12,12 @@ $susy: (columns: 12, container: 1200px, global-box-sizing: border-box);
   @include clearfix();
 }
 
+#mainContent {
+  &:focus {
+    outline: none;
+  }
+}
+
 // Skip to main content
 a.dol-skip-to-main {
   display: block;

--- a/DOL.WHD.Section14c.Web/src/styles/modules/fileUpload.scss
+++ b/DOL.WHD.Section14c.Web/src/styles/modules/fileUpload.scss
@@ -8,8 +8,7 @@
     position: relative;
     max-width: 46rem;
     width: 100%;
-    height: 50px;
-    
+    height: 50px;  
     
     .usa-button-primary {
         position: absolute;
@@ -50,9 +49,18 @@
         outline: none;
         padding: 1rem .7em;
         width: 100%;
-        z-index: 1;        
+        z-index: 1;   
+        background-color: #fff;     
     }
 
+}
+
+label {
+    + .usa-input-error-message + attachment-field {
+        .dol-file-upload-ui {
+            margin-top: 6px;
+        }
+    }
 }
 
 // List of files that have been uploaded, with Delete button for each file


### PR DESCRIPTION
#### What's this PR do?

Fixes various a11y issues as noted by Michelle in #296.

- Fixed IDs in the date field component so the number comes last, not first

- Added the capability to pass an input ID to the Attachment Field directive, so the file upload input ID can be matched by the  `<label for="">` attribute in the page. **After this PR is merged, I will add the `for=""` attributes and input IDs in other pages that have file upload inputs.**

- Added Enter key functionality to the Skip to Main Content link.
