### PR TITLE
Re-enables coverage reporting on client side

### DIFF
--- a/DOL.WHD.Section14c.Web/karma.conf.js
+++ b/DOL.WHD.Section14c.Web/karma.conf.js
@@ -36,7 +36,7 @@ module.exports = function(config) {
     // test results reporter to use
     // possible values: 'dots', 'progress'
     // available reporters: https://npmjs.org/browse/keyword/karma-reporter
-    reporters: [  'spec', 'progress', 'coverage', 'coveralls'],
+    reporters: [  'spec', 'coverage', 'coveralls'],
 
     // web server port
     port: 9876,

--- a/DOL.WHD.Section14c.Web/webpack.config.js
+++ b/DOL.WHD.Section14c.Web/webpack.config.js
@@ -25,17 +25,17 @@ module.exports = {
   module: {
     preLoaders: [
       {
-        test: /\.jsx?$/,
-        exclude: /node_modules/,
-        loader: 'eslint'
-      },
-      {
         test: /\.js$/,
         include: path.resolve('src/modules/'),
         loader: 'istanbul-instrumenter',
         query: {
           esModules: true
         }
+      },
+      {
+        test: /\.js?$/,
+        exclude: /node_modules/,
+        loader: 'eslint'
       }
     ],
     loaders: [

--- a/DOL.WHD.Section14c.Web/webpack.config.js
+++ b/DOL.WHD.Section14c.Web/webpack.config.js
@@ -28,6 +28,14 @@ module.exports = {
         test: /\.jsx?$/,
         exclude: /node_modules/,
         loader: 'eslint'
+      },
+      {
+        test: /\.js$/,
+        include: path.resolve('src/modules/'),
+        loader: 'istanbul-instrumenter',
+        query: {
+          esModules: true
+        }
       }
     ],
     loaders: [


### PR DESCRIPTION
#### What's this PR do?

Adds the `istanbul-instrumenter` back to the webpack config so coverage is generated correctly.

#### Where should the reviewer start?

#### How should this be manually tested?

* Make sure everything still builds correctly
* Make sure coverage reports are dumped in the `coverage` directory
* Make sure the coverage reports aren't empty

#### Any background context you want to provide?

Coverage was disabled in #325.  The coverage instrumentation causes linting errors during `npm test`.  If that causes problems, we can remove linting from the karma config and just run it separately, or update the test script to something like `eslint && karma`.

#### What are the relevant tickets?

#330 - Re-enable coverage metrics