### PR TITLE
fixes template urls after moving routes out of app.js

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/routes.js
+++ b/DOL.WHD.Section14c.Web/src/modules/routes.js
@@ -15,14 +15,14 @@ module.exports = function (app) {
       })
       .when('/changePassword', {
         controller: 'changePasswordPageController',
-        templateUrl: './pages/changePasswordPageTemplate.html',
+        template: require('./pages/changePasswordPageTemplate.html'),
         access: config.access.ROUTE_PUBLIC,
         label: 'Change Password',
         parent: '/'
       })
       .when('/forgotPassword', {
         controller: 'forgotPasswordPageController',
-        templateUrl: './pages/forgotPasswordPageTemplate.html',
+        template: require('./pages/forgotPasswordPageTemplate.html'),
         access: config.access.ROUTE_PUBLIC,
         label: 'Forgot Password',
         parent: '/'
@@ -34,12 +34,12 @@ module.exports = function (app) {
       })
       .when('/register', {
         controller: 'userRegistrationPageController',
-        templateUrl: './pages/userRegistrationPageTemplate.html',
+        template: require('./pages/userRegistrationPageTemplate.html'),
         access: config.access.ROUTE_PUBLIC
       })
       .when('/account/:userId', {
         controller: 'accountPageController',
-        templateUrl: './pages/accountPageTemplate.html',
+        template: require('./pages/accountPageTemplate.html'),
         access: config.access.ROUTE_LOGGEDIN
       })
       .when('/section/assurances', {
@@ -98,7 +98,7 @@ module.exports = function (app) {
       })
       .when('/admin/users', {
         controller: 'userManagementPageController',
-        templateUrl: './pages/userManagementPageTemplate.html',
+        template: require('./pages/userManagementPageTemplate.html'),
         access: config.access.ROUTE_ADMIN
       })
       .when('/admin/:app_id', {

--- a/DOL.WHD.Section14c.Web/src/modules/routes.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/routes.test.js
@@ -6,17 +6,11 @@ describe('sectionAssurancesController', function() {
   it('should map routes to controllers', function() {
     inject(function($route) {
       expect($route.routes['/'].controller).toBe('landingPageController');
-      expect($route.routes['/changePassword'].templateUrl).toEqual('./pages/changePasswordPageTemplate.html');
       expect($route.routes['/changePassword'].controller).toEqual('changePasswordPageController');
-      expect($route.routes['/forgotPassword'].templateUrl).toEqual('./pages/forgotPasswordPageTemplate.html');
       expect($route.routes['/forgotPassword'].controller).toEqual('forgotPasswordPageController');
-      expect($route.routes['/login'].templateUrl).toEqual('./pages/userLoginPageTemplate.html');
       expect($route.routes['/login'].controller).toEqual('userLoginPageController');
-      expect($route.routes['/register'].templateUrl).toEqual('./pages/userRegistrationPageTemplate.html');
       expect($route.routes['/register'].controller).toEqual('userRegistrationPageController');
-      expect($route.routes['/account/:userId'].templateUrl).toEqual('./pages/accountPageTemplate.html');
       expect($route.routes['/account/:userId'].controller).toEqual('accountPageController');
-      expect($route.routes['/admin/users'].templateUrl).toEqual('./pages/userManagementPageTemplate.html');
       expect($route.routes['/admin/users'].controller).toEqual('userManagementPageController');
       expect($route.routes['/section/assurances'].template).toEqual('<form-section><section-assurances></section-assurances></form-section>');
       expect($route.routes['/section/app-info'].template).toEqual('<form-section><section-app-info></section-app-info></form-section>');


### PR DESCRIPTION
#### What's this PR do?
- Fixes template urls in routes.js (routes that were using templateUrl were breaking after routes were moved out of app.js)

#### What are the relevant tickets?
#472 
- Forgot password, and change password pages were also not working

#### Screenshots (if appropriate)
#### Questions:
