### PR TITLE
Adds an icon to error messages for color blind users

### DIFF
--- a/DOL.WHD.Section14c.Web/src/styles/feedback.scss
+++ b/DOL.WHD.Section14c.Web/src/styles/feedback.scss
@@ -173,3 +173,24 @@ p.dol-feedback-message {
     }
   }  
 }
+
+// Form Field Error Message Styling
+// ----------------------------------------
+
+.usa-input-error-message {
+  position: relative;
+  padding-left: 27px;
+  margin-bottom: 4px;
+
+  &:before {
+    content: "";
+    top: 2px;
+    left: -2px;
+    position: absolute;
+    width: 20px;
+    height: 20px;
+    background: url('../images/dol-error-red.png') center center;
+    background: url('../images/dol-error-red.svg') center center;
+    background-size: 20px 20px;
+  }  
+}


### PR DESCRIPTION
#### What's this PR do?

Adds an exclamation point icon to form field error messages, so color blind users can scan more easily for error messages (instead of the message being red text only).

#### What are the relevant tickets?

#540 
