### PR TITLE
Account lockout Update

### DIFF
--- a/DOL.WHD.Section14c.Api/App_Data/AccountLockedOutEmailTemplate.txt
+++ b/DOL.WHD.Section14c.Api/App_Data/AccountLockedOutEmailTemplate.txt
@@ -1,0 +1,3 @@
+﻿Your account has been locked out for 15 minutes due to multiple failed login attempts.
+
+Sincerely

--- a/DOL.WHD.Section14c.Api/App_GlobalResources/LocalizedText.Designer.cs
+++ b/DOL.WHD.Section14c.Api/App_GlobalResources/LocalizedText.Designer.cs
@@ -70,6 +70,51 @@ namespace DOL.WHD.Section14c.Api.App_GlobalResources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Login failure.
+        /// </summary>
+        internal static string LoginFailureMessage {
+            get {
+                return ResourceManager.GetString("LoginFailureMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your account has been locked out for {0} minutes due to multiple failed login attempts..
+        /// </summary>
+        internal static string LoginFailureMessageAccountLockedOut {
+            get {
+                return ResourceManager.GetString("LoginFailureMessageAccountLockedOut", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Email not confirmed.
+        /// </summary>
+        internal static string LoginFailureMessageEmailNotConfirmed {
+            get {
+                return ResourceManager.GetString("LoginFailureMessageEmailNotConfirmed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Password expired.
+        /// </summary>
+        internal static string LoginFailureMessagePasswordExpired {
+            get {
+                return ResourceManager.GetString("LoginFailureMessagePasswordExpired", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Login success.
+        /// </summary>
+        internal static string LoginSuccessMessage {
+            get {
+                return ResourceManager.GetString("LoginSuccessMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Password does not meet complexity requirements..
         /// </summary>
         internal static string PasswordComplexityCheckFailedMessage {

--- a/DOL.WHD.Section14c.Api/App_GlobalResources/LocalizedText.resx
+++ b/DOL.WHD.Section14c.Api/App_GlobalResources/LocalizedText.resx
@@ -120,6 +120,21 @@
   <data name="InvalidUserNameorPassword" xml:space="preserve">
     <value>The user name or password is incorrect.</value>
   </data>
+  <data name="LoginFailureMessage" xml:space="preserve">
+    <value>Login failure</value>
+  </data>
+  <data name="LoginFailureMessageAccountLockedOut" xml:space="preserve">
+    <value>Your account has been locked out for {0} minutes due to multiple failed login attempts.</value>
+  </data>
+  <data name="LoginFailureMessageEmailNotConfirmed" xml:space="preserve">
+    <value>Email not confirmed</value>
+  </data>
+  <data name="LoginFailureMessagePasswordExpired" xml:space="preserve">
+    <value>Password expired</value>
+  </data>
+  <data name="LoginSuccessMessage" xml:space="preserve">
+    <value>Login success</value>
+  </data>
   <data name="PasswordComplexityCheckFailedMessage" xml:space="preserve">
     <value>Password does not meet complexity requirements.</value>
   </data>

--- a/DOL.WHD.Section14c.Api/App_Start/Startup.Auth.cs
+++ b/DOL.WHD.Section14c.Api/App_Start/Startup.Auth.cs
@@ -46,6 +46,7 @@ namespace DOL.WHD.Section14c.Api
             {
                 AuthenticationType = DefaultAuthenticationTypes.ApplicationCookie,
                 ExpireTimeSpan = TimeSpan.FromMinutes(AppSettings.Get<double>("AccessTokenExpireTimeSpanMinutes")),
+                CookieDomain = AppSettings.Get<string>("AuthenticationCookieDomain"),
                 Provider = new CookieAuthenticationProvider
                 {
                     OnValidateIdentity = ctx =>

--- a/DOL.WHD.Section14c.Api/DOL.WHD.Section14c.Api.csproj
+++ b/DOL.WHD.Section14c.Api/DOL.WHD.Section14c.Api.csproj
@@ -281,6 +281,7 @@
     <Compile Include="Startup.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Content Include="App_Data\AccountLockedOutEmailTemplate.txt" />
     <Content Include="App_Data\CertificationTeamEmailTemplate.txt" />
     <Content Include="App_Data\EmployerEmailTemplate.txt" />
     <Content Include="App_Data\HtmlTemplates\0-ApplicationCoverPage.html" />

--- a/DOL.WHD.Section14c.Api/Parameters.xml
+++ b/DOL.WHD.Section14c.Api/Parameters.xml
@@ -15,8 +15,8 @@
   <parameter name="AccessTokenExpireTimeSpanMinutes" defaultValue="20160">
     <parameterEntry kind="XmlFile" scope="web\.config$" match="/configuration/appSettings/add[@key='AccessTokenExpireTimeSpanMinutes']/@value" />
   </parameter>
-  <parameter name="EmailVerifyAndPaswordRestTokenExpireHours" defaultValue="6">
-    <parameterEntry kind="XmlFile" scope="web\.config$" match="/configuration/appSettings/add[@key='EmailVerifyAndPaswordRestTokenExpireHours']/@value" />
+  <parameter name="EmailVerifyAndPaswordResetTokenExpireHours" defaultValue="6">
+    <parameterEntry kind="XmlFile" scope="web\.config$" match="/configuration/appSettings/add[@key='EmailVerifyAndPaswordResetTokenExpireHours']/@value" />
   </parameter>
   <parameter name="AccessTokenExpireTimeSpanMinutes" defaultValue="3">
     <parameterEntry kind="XmlFile" scope="web\.config$" match="/configuration/appSettings/add[@key='AccessTokenExpireTimeSpanMinutes']/@value" />

--- a/DOL.WHD.Section14c.Api/Parameters.xml
+++ b/DOL.WHD.Section14c.Api/Parameters.xml
@@ -15,8 +15,8 @@
   <parameter name="AccessTokenExpireTimeSpanMinutes" defaultValue="20160">
     <parameterEntry kind="XmlFile" scope="web\.config$" match="/configuration/appSettings/add[@key='AccessTokenExpireTimeSpanMinutes']/@value" />
   </parameter>
-  <parameter name="EmailVeriryAndPaswordRestTokenExpireHours" defaultValue="6">
-    <parameterEntry kind="XmlFile" scope="web\.config$" match="/configuration/appSettings/add[@key='EmailVeriryAndPaswordRestTokenExpireHours']/@value" />
+  <parameter name="EmailVerifyAndPaswordRestTokenExpireHours" defaultValue="6">
+    <parameterEntry kind="XmlFile" scope="web\.config$" match="/configuration/appSettings/add[@key='EmailVerifyAndPaswordRestTokenExpireHours']/@value" />
   </parameter>
   <parameter name="AccessTokenExpireTimeSpanMinutes" defaultValue="3">
     <parameterEntry kind="XmlFile" scope="web\.config$" match="/configuration/appSettings/add[@key='AccessTokenExpireTimeSpanMinutes']/@value" />

--- a/DOL.WHD.Section14c.Api/Providers/ApplicationOAuthProvider.cs
+++ b/DOL.WHD.Section14c.Api/Providers/ApplicationOAuthProvider.cs
@@ -66,9 +66,7 @@ namespace DOL.WHD.Section14c.Api.Providers
                     {
                         // account locked
                         // use invalid user name or password message to avoid disclosing that a valid username was input
-                        var message = string.Format(
-                            "Your account has been locked out for {0} minutes due to multiple failed login attempts.",
-                            AppSettings.Get<int>("DefaultAccountLockoutTimeSpan"));
+                        var message = string.Format(App_GlobalResources.LocalizedText.LoginFailureMessageAccountLockedOut, AppSettings.Get<int>("DefaultAccountLockoutTimeSpan"));
                         context.SetError("locked_out", message);
                         // Get locked out email template
                         var accountLockedOutEmailTemplatePath = System.Web.Hosting.HostingEnvironment.MapPath(@"~/App_Data/AccountLockedOutEmailTemplate.txt");
@@ -76,14 +74,16 @@ namespace DOL.WHD.Section14c.Api.Providers
                         //Send Account Lock Out Email
                         await userManager.SendEmailAsync(user.Id, AppSettings.Get<string>("AccountLockedoutEmailSubject"), accountLockedOutEmailTemplateString);
                         await userManager.AddLoginAsync(user.Id, new Microsoft.AspNet.Identity.UserLoginInfo(Guid.NewGuid().ToString(), user.Email));
-                        throw new UnauthorizedAccessException(message);
+                        throw new UnauthorizedAccessException(string.Format("{0}: {1}", App_GlobalResources.LocalizedText.LoginFailureMessage, message));
                     }
                     if (!user.EmailConfirmed)
                     {
                         // email not confirmed
                         // use invalid user name or password message to avoid disclosing that a valid username was input
-                        context.SetError("invalid_grant", "Email not confirmed");
-                        eventInfo.Message = "Email not confirmed";
+                        context.SetError("invalid_grant", App_GlobalResources.LocalizedText.LoginFailureMessageEmailNotConfirmed);
+                        var message = string.Format("{0}: {1}", App_GlobalResources.LocalizedText.LoginFailureMessage, App_GlobalResources.LocalizedText.LoginFailureMessageEmailNotConfirmed);
+                        eventInfo.Message = message;
+                        throw new UnauthorizedAccessException(message);
                     }
                     else if (validCredentials == null)
                     {
@@ -98,13 +98,15 @@ namespace DOL.WHD.Section14c.Api.Providers
                         context.SetError("invalid_grant", App_GlobalResources.LocalizedText.InvalidUserNameorPassword);
                         //Update AspNetUserLogins Table
                         await userManager.AddLoginAsync(user.Id, new Microsoft.AspNet.Identity.UserLoginInfo(Guid.NewGuid().ToString(), user.Email));
-                        throw new UnauthorizedAccessException(string.Format("{0} Login Attempted: {1}", App_GlobalResources.LocalizedText.InvalidUserNameorPassword, loginAttempted +1));
+                        throw new UnauthorizedAccessException(string.Format("{0}: {1} Login Attempted: {2}", App_GlobalResources.LocalizedText.LoginFailureMessage, App_GlobalResources.LocalizedText.InvalidUserNameorPassword, loginAttempted +1));
                     }
                     else if (passwordExpired)
                     {
                         // password expired
-                        context.SetError("invalid_grant", "Password expired");
-                        eventInfo.Message = "Password expired";
+                        context.SetError("invalid_grant", App_GlobalResources.LocalizedText.LoginFailureMessagePasswordExpired);
+                        var message = string.Format("{0}: {1}", App_GlobalResources.LocalizedText.LoginFailureMessage, App_GlobalResources.LocalizedText.LoginFailureMessagePasswordExpired);
+                        eventInfo.Message = message;
+                        throw new UnauthorizedAccessException(message);
                     }
                     else
                     {
@@ -128,7 +130,7 @@ namespace DOL.WHD.Section14c.Api.Providers
                         await userManager.AddLoginAsync(user.Id, new Microsoft.AspNet.Identity.UserLoginInfo(Guid.NewGuid().ToString(), user.Email));
                         // logging of successful attempts
                         eventInfo.Level = LogLevel.Info;
-                        eventInfo.Message = "Login success";
+                        eventInfo.Message = App_GlobalResources.LocalizedText.LoginSuccessMessage;
                     }
                 }
                 else

--- a/DOL.WHD.Section14c.Api/Providers/ApplicationOAuthProvider.cs
+++ b/DOL.WHD.Section14c.Api/Providers/ApplicationOAuthProvider.cs
@@ -9,6 +9,8 @@ using Microsoft.Owin.Security;
 using Microsoft.Owin.Security.Cookies;
 using Microsoft.Owin.Security.OAuth;
 using DOL.WHD.Section14c.Common;
+using System.IO;
+using NLog;
 
 namespace DOL.WHD.Section14c.Api.Providers
 {
@@ -18,7 +20,7 @@ namespace DOL.WHD.Section14c.Api.Providers
     public class ApplicationOAuthProvider : OAuthAuthorizationServerProvider
     {
         private readonly string _publicClientId;
-
+        private static readonly Logger _logger = LogManager.GetCurrentClassLogger();
         /// <summary>
         /// 
         /// </summary>
@@ -40,77 +42,116 @@ namespace DOL.WHD.Section14c.Api.Providers
         /// <returns></returns>
         public override async Task GrantResourceOwnerCredentials(OAuthGrantResourceOwnerCredentialsContext context)
         {
-            var userManager = context.OwinContext.GetUserManager<ApplicationUserManager>();
-            var roleManager = context.OwinContext.Get<ApplicationRoleManager>();
-
-            var user = await userManager.Users.Include("Roles.Role").Include("Organizations").FirstOrDefaultAsync(x => x.UserName == context.UserName);
-            if (user != null)
+            LogEventInfo eventInfo = new LogEventInfo();
+            try
             {
-                var passwordExpired = false;
-                var passwordExpirationDays = AppSettings.Get<int>("PasswordExpirationDays");
-                if (passwordExpirationDays > 0)
+                var userManager = context.OwinContext.GetUserManager<ApplicationUserManager>();
+                var roleManager = context.OwinContext.Get<ApplicationRoleManager>();
+                eventInfo.Properties["CorrelationId"] = Guid.NewGuid().ToString();
+                eventInfo.LoggerName = "LoginAttempts";                
+                eventInfo.Properties["IsServiceSideLog"] = 1;
+                var user = await userManager.Users.Include("Roles.Role").Include("Organizations").FirstOrDefaultAsync(x => x.UserName == context.UserName);
+                if (user != null)
                 {
-                    passwordExpired = user.LastPasswordChangedDate.AddDays(passwordExpirationDays) < DateTime.Now;
-                } 
-                var validCredentials = await userManager.FindAsync(context.UserName, context.Password);
-                if (await userManager.IsLockedOutAsync(user.Id))
-                {
-                    // account locked
-                    // use invalid user name or password message to avoid disclosing that a valid username was input
-                    var message = string.Format(
-                        "Your account has been locked out for {0} minutes due to multiple failed login attempts.",
-                        AppSettings.Get<int>("DefaultAccountLockoutTimeSpan"));
-                    context.SetError("locked_out", message);
-                    return;
-                }
-                if (!user.EmailConfirmed)
-                {
-                    // email not confirmed
-                    // use invalid user name or password message to avoid disclosing that a valid username was input
-                    context.SetError("invalid_grant", App_GlobalResources.LocalizedText.InvalidUserNameorPassword);
-                }
-                else if (validCredentials == null)
-                {
-                    // invalid credentials
-                    // increment failed login count
-                    if (await userManager.GetLockoutEnabledAsync(user.Id))
+                    eventInfo.Properties["UserId"] = user.Id;
+                    eventInfo.Properties["UserName"] = user.UserName;
+                    var passwordExpired = false;
+                    var passwordExpirationDays = AppSettings.Get<int>("PasswordExpirationDays");
+                    if (passwordExpirationDays > 0)
                     {
-                        await userManager.AccessFailedAsync(user.Id);
+                        passwordExpired = user.LastPasswordChangedDate.AddDays(passwordExpirationDays) < DateTime.Now;
                     }
+                    var validCredentials = await userManager.FindAsync(context.UserName, context.Password);
+                    if (await userManager.IsLockedOutAsync(user.Id))
+                    {
+                        // account locked
+                        // use invalid user name or password message to avoid disclosing that a valid username was input
+                        var message = string.Format(
+                            "Your account has been locked out for {0} minutes due to multiple failed login attempts.",
+                            AppSettings.Get<int>("DefaultAccountLockoutTimeSpan"));
+                        context.SetError("locked_out", message);
+                        // Get locked out email template
+                        var accountLockedOutEmailTemplatePath = System.Web.Hosting.HostingEnvironment.MapPath(@"~/App_Data/AccountLockedOutEmailTemplate.txt");
+                        var accountLockedOutEmailTemplateString = File.ReadAllText(accountLockedOutEmailTemplatePath);
+                        //Send Account Lock Out Email
+                        await userManager.SendEmailAsync(user.Id, AppSettings.Get<string>("AccountLockedoutEmailSubject"), accountLockedOutEmailTemplateString);
+                        await userManager.AddLoginAsync(user.Id, new Microsoft.AspNet.Identity.UserLoginInfo(Guid.NewGuid().ToString(), user.Email));
+                        throw new UnauthorizedAccessException(message);
+                    }
+                    if (!user.EmailConfirmed)
+                    {
+                        // email not confirmed
+                        // use invalid user name or password message to avoid disclosing that a valid username was input
+                        context.SetError("invalid_grant", "Email not confirmed");
+                        eventInfo.Message = "Email not confirmed";
+                    }
+                    else if (validCredentials == null)
+                    {
+                        // invalid credentials
+                        // increment failed login count
+                        int loginAttempted = 0;
+                        if (await userManager.GetLockoutEnabledAsync(user.Id))
+                        {
+                            loginAttempted = await userManager.GetAccessFailedCountAsync(user.Id);
+                            await userManager.AccessFailedAsync(user.Id);                            
+                        }
+                        context.SetError("invalid_grant", App_GlobalResources.LocalizedText.InvalidUserNameorPassword);
+                        //Update AspNetUserLogins Table
+                        await userManager.AddLoginAsync(user.Id, new Microsoft.AspNet.Identity.UserLoginInfo(Guid.NewGuid().ToString(), user.Email));
+                        throw new UnauthorizedAccessException(string.Format("{0} Login Attempted: {1}", App_GlobalResources.LocalizedText.InvalidUserNameorPassword, loginAttempted +1));
+                    }
+                    else if (passwordExpired)
+                    {
+                        // password expired
+                        context.SetError("invalid_grant", "Password expired");
+                        eventInfo.Message = "Password expired";
+                    }
+                    else
+                    {
+                        // successful login
+                        ClaimsIdentity oAuthIdentity = await user.GenerateUserIdentityAsync(userManager, roleManager,
+                            OAuthDefaults.AuthenticationType);
 
-                    context.SetError("invalid_grant", App_GlobalResources.LocalizedText.InvalidUserNameorPassword);
-                }
-                else if (passwordExpired)
-                {
-                    // password expired
-                    context.SetError("invalid_grant", "Password expired");
+                        ClaimsIdentity cookiesIdentity = await user.GenerateUserIdentityAsync(userManager, roleManager,
+                            CookieAuthenticationDefaults.AuthenticationType);
+
+                        AuthenticationProperties properties = CreateProperties(user.Email);
+
+                        AuthenticationTicket ticket = new AuthenticationTicket(oAuthIdentity, properties);
+                        context.Validated(ticket);
+                        context.Request.Context.Authentication.SignIn(cookiesIdentity);
+
+                        // reset failed attempts count
+                        await userManager.ResetAccessFailedCountAsync(user.Id);
+
+                        //Update AspNetUserLogins Table
+                        await userManager.AddLoginAsync(user.Id, new Microsoft.AspNet.Identity.UserLoginInfo(Guid.NewGuid().ToString(), user.Email));
+                        // logging of successful attempts
+                        eventInfo.Level = LogLevel.Info;
+                        eventInfo.Message = "Login success";
+                    }
                 }
                 else
                 {
-                    // successful login
-                    ClaimsIdentity oAuthIdentity = await user.GenerateUserIdentityAsync(userManager, roleManager,
-                        OAuthDefaults.AuthenticationType);
-
-                    ClaimsIdentity cookiesIdentity = await user.GenerateUserIdentityAsync(userManager, roleManager,
-                        CookieAuthenticationDefaults.AuthenticationType);
-
-                    AuthenticationProperties properties = CreateProperties(user.Email);
-
-                    AuthenticationTicket ticket = new AuthenticationTicket(oAuthIdentity, properties);
-                    context.Validated(ticket);
-                    context.Request.Context.Authentication.SignIn(cookiesIdentity);
-
-                    // reset failed attempts count
-                    await userManager.ResetAccessFailedCountAsync(user.Id);
+                    // invalid username
+                    context.SetError("invalid_grant", App_GlobalResources.LocalizedText.InvalidUserNameorPassword);
+                    throw new UnauthorizedAccessException(App_GlobalResources.LocalizedText.InvalidUserNameorPassword);
                 }
             }
-            else
+            catch(Exception ex)
             {
-                // invalid username
-                context.SetError("invalid_grant", App_GlobalResources.LocalizedText.InvalidUserNameorPassword);
+                // logging of unsuccessful attempts
+                eventInfo.Message = ex.Message;
+                eventInfo.Exception = ex;
+                eventInfo.Level = LogLevel.Error;
+            }
+            finally
+            {
+                // Write log to database
+                _logger.Log(eventInfo);
             }
         }
-
+        
         /// <summary>
         /// 
         /// </summary>

--- a/DOL.WHD.Section14c.Api/Providers/ApplicationOAuthProvider.cs
+++ b/DOL.WHD.Section14c.Api/Providers/ApplicationOAuthProvider.cs
@@ -57,7 +57,11 @@ namespace DOL.WHD.Section14c.Api.Providers
                 {
                     // account locked
                     // use invalid user name or password message to avoid disclosing that a valid username was input
-                    context.SetError("invalid_grant", App_GlobalResources.LocalizedText.InvalidUserNameorPassword);
+                    var message = string.Format(
+                        "Your account has been locked out for {0} minutes due to multiple failed login attempts.",
+                        AppSettings.Get<int>("DefaultAccountLockoutTimeSpan"));
+                    context.SetError("locked_out", message);
+                    return;
                 }
                 if (!user.EmailConfirmed)
                 {

--- a/DOL.WHD.Section14c.Api/Web.config
+++ b/DOL.WHD.Section14c.Api/Web.config
@@ -18,9 +18,10 @@
     <add key="UserLockoutEnabledByDefault" value="true" />
     <add key="DefaultAccountLockoutTimeSpan" value="15" />
     <add key="MaxFailedAccessAttemptsBeforeLockout" value="3" />
-    <add key="EmailVerifyAndPaswordRestTokenExpireHours" value="6 " />
+    <add key="EmailVerifyAndPaswordResetTokenExpireHours" value="6" />
     <add key="PasswordExpirationDays" value="90" /> <!-- Number of days before user password expires. A value of 0 disables password expiration -->
     <add key="AccessTokenExpireTimeSpanMinutes" value="20160" /> <!-- 14 days -->
+    <add key="AuthenticationCookieDomain" value=".dol.gov"/>
     <add key="AttachmentRepositoryRootFolder" value="C:\temp\DOL-WHD-Section14c-Attachments\" />
     <add key="AllowedFileNamesRegex" value="^.*\.(pdf|jpg|jpeg|png)$" />
     <add key="AllowedMaximumContentLength" value="5242880" /> <!-- Allowed maximum file size in Bytes -->

--- a/DOL.WHD.Section14c.Api/Web.config
+++ b/DOL.WHD.Section14c.Api/Web.config
@@ -18,7 +18,7 @@
     <add key="UserLockoutEnabledByDefault" value="true" />
     <add key="DefaultAccountLockoutTimeSpan" value="15" />
     <add key="MaxFailedAccessAttemptsBeforeLockout" value="3" />
-    <add key="EmailVeriryAndPaswordRestTokenExpireHours" value="6 " />
+    <add key="EmailVerifyAndPaswordRestTokenExpireHours" value="6 " />
     <add key="PasswordExpirationDays" value="90" /> <!-- Number of days before user password expires. A value of 0 disables password expiration -->
     <add key="AccessTokenExpireTimeSpanMinutes" value="20160" /> <!-- 14 days -->
     <add key="AttachmentRepositoryRootFolder" value="C:\temp\DOL-WHD-Section14c-Attachments\" />
@@ -28,6 +28,7 @@
     <add key="RequireHttps" value="true" />
     <add key="CertificationTeamEmailAddress" value="Striegel.Elizabeth@dol.gov" />
     <add key="ApplicationSubmittedEmailSubject" value="Section 14(c) Online Application Submission" />
+    <add key="AccountLockedoutEmailSubject" value="Section 14(c) Online Application Account Locked out" />
     <add key="HttpClientConnectionLeaseTimeout" value="60000" />
     <add key="PasswordComplexityScore" value="2" />
   </appSettings>

--- a/DOL.WHD.Section14c.DataAccess/Identity/IdentityConfig.cs
+++ b/DOL.WHD.Section14c.DataAccess/Identity/IdentityConfig.cs
@@ -53,7 +53,7 @@ namespace DOL.WHD.Section14c.DataAccess.Identity
                 manager.UserTokenProvider = new DataProtectorTokenProvider<ApplicationUser>(dataProtectionProvider.Create("ASP.NET Identity"))
                 {
                     //Code for email confirmation and reset password life time
-                    TokenLifespan = TimeSpan.FromHours(AppSettings.Get<double>("EmailVerifyAndPaswordRestTokenExpireHours"))
+                    TokenLifespan = TimeSpan.FromHours(AppSettings.Get<double>("EmailVerifyAndPaswordResetTokenExpireHours"))
                 };
             }
             return manager;

--- a/DOL.WHD.Section14c.DataAccess/Identity/IdentityConfig.cs
+++ b/DOL.WHD.Section14c.DataAccess/Identity/IdentityConfig.cs
@@ -53,7 +53,7 @@ namespace DOL.WHD.Section14c.DataAccess.Identity
                 manager.UserTokenProvider = new DataProtectorTokenProvider<ApplicationUser>(dataProtectionProvider.Create("ASP.NET Identity"))
                 {
                     //Code for email confirmation and reset password life time
-                    TokenLifespan = TimeSpan.FromHours(AppSettings.Get<double>("EmailVeriryAndPaswordRestTokenExpireHours"))
+                    TokenLifespan = TimeSpan.FromHours(AppSettings.Get<double>("EmailVerifyAndPaswordRestTokenExpireHours"))
                 };
             }
             return manager;

--- a/DOL.WHD.Section14c.Web/src/modules/components/userLoginForm/userLoginFormController.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/userLoginForm/userLoginFormController.js
@@ -14,7 +14,10 @@ module.exports = function(ngModule) {
 
     var vm = this;
     vm.stateService = stateService;
-    vm.loginError = false;
+    vm.loginError= {
+      status: false,
+      message: ''
+    };
 
     $scope.formVals = {
       email: '',
@@ -53,9 +56,20 @@ module.exports = function(ngModule) {
         $location.path('/changePassword');
         $scope.$apply();
       }
-
-      if (error.status === 400) {
-        vm.loginError = true;
+      if (error.status === 400) {        
+        if(error.data.error === 'locked_out'){
+          // update error message
+          vm.loginError= {
+            status: true,
+            message: error.data.error_description
+          };
+        }
+        else{
+          vm.loginError= {
+            status: true,
+            message: 'The email or password entered does not match our records.'
+          };
+        }
       } else {
         // catch all error, currently possible to get a 500 if the database server is not reachable
         vm.unknownError = true;
@@ -63,7 +77,10 @@ module.exports = function(ngModule) {
     };
 
     this.clearError = function() {
-      vm.loginError = false;
+      vm.loginError= {
+        status: false,
+        message: ''
+      };
       vm.unknownError = false;
     };
 

--- a/DOL.WHD.Section14c.Web/src/modules/components/userLoginForm/userLoginFormController.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/userLoginForm/userLoginFormController.js
@@ -56,19 +56,16 @@ module.exports = function(ngModule) {
         $location.path('/changePassword');
         $scope.$apply();
       }
-      if (error.status === 400) {        
+      vm.loginError = {
+        status: true
+      }
+      if (error.status === 400) {
         if(error.data.error === 'locked_out'){
           // update error message
-          vm.loginError= {
-            status: true,
-            message: error.data.error_description
-          };
+          vm.loginError.message = error.data.error_description
         }
         else{
-          vm.loginError= {
-            status: true,
-            message: 'The email or password entered does not match our records.'
-          };
+          vm.loginError.message = "The email or password entered does not match our records."
         }
       } else {
         // catch all error, currently possible to get a 500 if the database server is not reachable

--- a/DOL.WHD.Section14c.Web/src/modules/components/userLoginForm/userLoginFormController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/userLoginForm/userLoginFormController.test.js
@@ -41,7 +41,7 @@ describe('userLoginFormController', function() {
     controller.unknownError = true;
     controller.clearError();
 
-    expect(controller.loginError).toBe(false);
+    expect(controller.loginError.status).toBe(false);
     expect(controller.unknownError).toBe(false);
   });
 
@@ -89,7 +89,7 @@ describe('userLoginFormController', function() {
     userLogin.reject({ status: 400 });
     scope.$apply();
 
-    expect(controller.loginError).toBe(true);
+    expect(controller.loginError.status).toBe(true);
   });
 
   it('on user info success', function() {

--- a/DOL.WHD.Section14c.Web/src/modules/components/userLoginForm/userLoginFormTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/userLoginForm/userLoginFormTemplate.html
@@ -7,17 +7,17 @@
         <p class="usa-alert-text">An error occurred while connecting to the server. Please try again later if the error persists.</p>
       </div>
     </div>
-
-    <div class="usa-alert usa-alert-error" role="alert" ng-show="vm.loginError">
+ 
+    <div class="usa-alert usa-alert-error" role="alert" ng-show="vm.loginError.status">
       <div class="usa-alert-body">
-        <p class="usa-alert-text">The email or password entered does not match our records.</p>
+        <p class="usa-alert-text">{{ vm.loginError.message }} </p>
       </div>
-    </div>
-    <div ng-class="vm.loginError ? 'usa-input-error' : ''">
+    </div>    
+    <div ng-class="vm.loginError.status ? 'usa-input-error' : ''">
       <label for="userName">Email</label>
       <input name="userName" id="userName" type="email" ng-model="formVals.email" />
     </div>
-    <div ng-class="(vm.loginError ? 'usa-input-error' : '') + ' ' + 'password-wrap'">
+    <div ng-class="(vm.loginError.status ? 'usa-input-error' : '') + ' ' + 'password-wrap'">
       <label for="password">Password</label>
       <input name="password" id="password" type="{{inputType}}" ng-model="formVals.pass" />
       <div class="showpass">


### PR DESCRIPTION
#### What's this PR do?
Fixed account locked out not working issue. Updated account locked out error message and added new  feature to send email to alert user that his/her account has been locked out. Added logging of unsuccessful attempts to the error log table. Updated authentication token to include .dol.gov domain. Fixed app-setting 'EmailVerifyAndPaswordResetTokenExpireHours' typo.
#### How should this be manually tested?
Login to the 14c Application with wrong password. After three attempts, the account should to locked and user should receive an email to alert his/her account has been locked for 15 minutes. User should be able to login to his/her application 15 minutes later with the correct user name and password.
#### What are the relevant tickets?
#558 - Implement Token expiration for Authentication, Confirmation email, & Password reset 
#80 - As a WHD Security Officer, I would like the system to log unsuccessful login attempts and put a lock on accounts after a certain amount
#141 - As an Applicant, I would like to be notified when my account has been locked out and how to re-access it. 