### PR TITLE
routing access fix, omb text edits, datatable formatting

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/app.js
+++ b/DOL.WHD.Section14c.Web/src/modules/app.js
@@ -99,6 +99,7 @@ app.run(function(
   stateService,
   autoSaveService,
   authService,
+  apiService,
   $q
 ) {
 
@@ -136,9 +137,19 @@ app.run(function(
         if (!next.$$route) {
           return;
         }
+
         let userAccess = stateService.IsPointOfContact
           ? routeConfig.access.ROUTE_ADMIN
           : stateService.loggedIn ? routeConfig.access.ROUTE_USER : routeConfig.access.ROUTE_PUBLIC;
+        if(userAccess === routeConfig.access.ROUTE_USER) {
+          apiService.userInfo(stateService.access_token).then(function(result) {
+            if(result.data.organizations.length <= 0) {
+              $location.path("/employerRegistration");
+            }
+          }).catch(function(error) {
+            $log.warn('Error in authenticating user or getting saved application.', error)
+          });
+        }
         if (!routeConfig.checkRouteAccess(next.$$route, userAccess)) {
           // user does not have adequate permissions to access the route so redirect
           $location.path('/' + (userAccess === routeConfig.access.ROUTE_ADMIN ? 'admin' : 'login'));

--- a/DOL.WHD.Section14c.Web/src/modules/components/attachmentField/attachmentFieldTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/attachmentField/attachmentFieldTemplate.html
@@ -25,7 +25,7 @@
     <button aria-controls="modal" class="red-button modal-trigger" ng-click="vm.showDeleteFileConfirmationModal()">Delete<span class="hide"> {{attachmentName}}</span></button>
   </li>
 </div>
-<div ng-show="vm.upload.status == 'Invalid'" class="dol-feedback-error">
+<div focus-on="vm.upload.status === 'Invalid'" tabindex="0" ng-show="vm.upload.status == 'Invalid'" class="dol-feedback-error">
     <p class="dol-feedback-message">
       <strong>{{vm.upload.message}}</strong> <span>{{attachmentName}} was not uploaded.</span><span ng-show="vm.upload.message === 'File Size too large.'"> Files cannot be larger than 5MB.</span><span ng-show="vm.upload.message === 'Invalid File Type.'"> File types accepted: .pdf, .jpg, .jpeg, .png, and .csv</span>
     </p>

--- a/DOL.WHD.Section14c.Web/src/modules/components/attachmentsField/attachmentsFieldTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/components/attachmentsField/attachmentsFieldTemplate.html
@@ -22,7 +22,7 @@
           <strong>Uploading:</strong> {{attachmentName}}
         </p>
     </div>
-    <div ng-show="upload.status == 'Invalid'" class="dol-feedback-error">
+    <div focus-on="upload.status === 'Invalid'" tabindex="0" ng-show="upload.status == 'Invalid'" class="dol-feedback-error">
         <p class="dol-feedback-message">
           <strong>{{upload.message}}</strong> <span>{{attachmentName}} was not uploaded.</span><span ng-show="upload.message === 'File Size too large.'"> Files cannot be larger than 5MB.</span><span ng-show="upload.message === 'Invalid File Type.'"> File types accepted: .pdf, .jpg, .jpeg, .png, and .csv</span>
         </p>

--- a/DOL.WHD.Section14c.Web/src/modules/pages/dashboardTableConfig.js
+++ b/DOL.WHD.Section14c.Web/src/modules/pages/dashboardTableConfig.js
@@ -8,7 +8,6 @@ var applicationColumns = [
   { data: 'employerName', title: "Employer" },
   { data: 'ein', title: "EIN"},
   { data: 'employerAddress',  title: "Address"},
-  { data: 'createdAt', title: "Created At" },
   { data: 'lastModifiedAt',  title: "Date Submitted"},
   { data: 'applicationStatus',  title: "Status"},
   { data: 'action', title: 'PDF Version'}

--- a/DOL.WHD.Section14c.Web/src/modules/pages/employerRegistrationTemplate.html
+++ b/DOL.WHD.Section14c.Web/src/modules/pages/employerRegistrationTemplate.html
@@ -44,7 +44,7 @@
     </p>
     <div class="dol-form-question-block" ng-class="validationProperties.hasTradeNameRequired ? 'usa-input-error' : ''">
       <fieldset class="usa-fieldset-inputs usa-sans">
-        <legend class="dol-form-question-text">Has this employer ever previously held a 14(c) certificate?</legend>
+        <legend class="dol-form-question-text">Has this employer ever previously held a section 14(c) certificate?</legend>
         <span class="usa-input-error-message" role="alert" tabindex="0" ng-show="validationProperties.hasTradeNameRequired">
           Please indicate whether this employer ever previously held a 14(c) certificate.
         </span>

--- a/DOL.WHD.Section14c.Web/src/modules/pages/landingPageController.js
+++ b/DOL.WHD.Section14c.Web/src/modules/pages/landingPageController.js
@@ -114,8 +114,7 @@ module.exports = function(ngModule) {
             ein: element.employer.ein,
             employerId: element.employer.id,
             employerName: element.employer.legalName,
-            createdAt: dateFilter(element.createdAt) + " at " + new Date(element.createdAt).toLocaleTimeString(),
-            lastModifiedAt: dateFilter(element.lastModifiedAt) + " at " + new Date(element.lastModifiedAt).toLocaleTimeString(),
+            lastModifiedAt: dateFilter(element.lastModifiedAt),
             employerAddress: element.employer.physicalAddress.streetAddress + " " + element.employer.physicalAddress.city + ", " + element.employer.physicalAddress.state + " " + element.employer.physicalAddress.zipCode
           }
           if(element.applicationId && element.applicationStatus) {

--- a/DOL.WHD.Section14c.Web/src/modules/services/authService.js
+++ b/DOL.WHD.Section14c.Web/src/modules/services/authService.js
@@ -77,6 +77,8 @@ module.exports = function(ngModule) {
                 d.reject(error);
               });
             }
+          } else {
+            $location.path("/employerRegistration");
           }
           if (!stateService.IsPointOfContact) {
             d.resolve();


### PR DESCRIPTION
#### What's this PR do?
- OMB text edit for employer page
- removes created at column on dashboard table
- formats last modified column to only include date (and not time)
- reconfigures routes to redirect user to employer registration page if they have not yet registered an employer

#### What are the relevant tickets?
- #469, #631, #569, #568

