### PR TITLE
Fix lint errors

### DIFF
--- a/DOL.WHD.Section14c.Web/src/modules/components/accountManagementControls/accountGridController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/accountManagementControls/accountGridController.test.js
@@ -1,6 +1,7 @@
 describe('accountGridController', function() {
   var scope, $q, mockApiService, mockAdminApiService, mockLocation, mockStateService;
   var accountGridController, getAccounts;
+  var resetPassword, resendCode, resendConfirmationEmail;
 
   beforeEach(module('14c'));
 
@@ -125,7 +126,7 @@ describe('accountGridController', function() {
   });
 
   it('submit should use right api call', function() {
-    var controller = accountGridController();
+    accountGridController();
     scope.resendCodeModalIsVisible = true;
     scope.submit();
     expect(mockAdminApiService.resendCode).toHaveBeenCalled();

--- a/DOL.WHD.Section14c.Web/src/modules/components/attachmentField/attachmentFieldController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/attachmentField/attachmentFieldController.test.js
@@ -1,6 +1,6 @@
 describe('attachmentFieldController', function() {
   var scope, $q, mockApiService, attachmentFieldController;
-  var uploadAttachment, deleteAttachment, mockEnv;
+  var uploadAttachment, deleteAttachment, mockEnv, controller;
 
   beforeEach(module('14c'));
 

--- a/DOL.WHD.Section14c.Web/src/modules/components/attachmentsField/attachmentsFieldController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/attachmentsField/attachmentsFieldController.test.js
@@ -1,6 +1,7 @@
 describe('attachmentsFieldController', function() {
   var scope, $q, mockApiService, attachmentsFieldController;
   var uploadAttachment, deleteAttachment, mockStateService, mockEnv;
+  var controller;
 
   beforeEach(module('14c'));
 

--- a/DOL.WHD.Section14c.Web/src/modules/components/changePasswordForm/changePasswordFormController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/changePasswordForm/changePasswordFormController.test.js
@@ -1,5 +1,5 @@
 describe('changePasswordFormController', function() {
-  var scope, $q, mockApiService, mockStateService;
+  var scope, $q, mockApiService, mockStateService, mockLocation;
   var changePasswordFormController, changePassword;
 
   beforeEach(module('14c'));

--- a/DOL.WHD.Section14c.Web/src/modules/components/dolHeader/dolHeaderController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/dolHeader/dolHeaderController.test.js
@@ -35,7 +35,7 @@ describe('dolHeaderController', function() {
   });
 
   it('starts idle watch on resume', function() {
-    var controller = dolHeaderController();
+    dolHeaderController();
     scope.continueWorking();
     scope.$apply();
     expect(mockIdleService.watch).toHaveBeenCalled();
@@ -43,21 +43,21 @@ describe('dolHeaderController', function() {
   });
 
   it('closes idle modal', function() {
-    var controller = dolHeaderController();
+    dolHeaderController();
     scope.hideIdleWarning();
     scope.$apply();
     expect(scope.modalIsVisible).toEqual(false);
   });
 
   it('shows idle modal', function() {
-    var controller = dolHeaderController();
+    dolHeaderController();
     scope.showIdleWarning();
     scope.$apply();
     expect(scope.modalIsVisible).toEqual(true);
   });
 
   it('logouts out after timeout is met', function() {
-    var controller = dolHeaderController();
+    dolHeaderController();
     scope.$$listeners.IdleTimeout[0]();
     scope.$apply();
     expect(mockStateService.logOut).toHaveBeenCalled();
@@ -66,7 +66,7 @@ describe('dolHeaderController', function() {
   });
 
   it('shows modal for inactivity warning', function() {
-    var controller = dolHeaderController();
+    dolHeaderController();
     scope.$$listeners.IdleWarn[0]();
     scope.$apply();
     expect(scope.modalIsVisible).toEqual(true);

--- a/DOL.WHD.Section14c.Web/src/modules/components/focusOn/focusOnDirective.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/focusOn/focusOnDirective.test.js
@@ -1,13 +1,13 @@
 describe('focusOn', function() {
   beforeEach(module('14c'));
 
+  var element, rootScope;
 
-  var element, rootScope, compiled;
   beforeEach(function() {
     element = angular.element('<input focus-on="true"/>');
     inject(function($rootScope, $compile) {
       rootScope = $rootScope;
-      compiled = $compile(element)(rootScope);
+      $compile(element)(rootScope);
     });
   });
 

--- a/DOL.WHD.Section14c.Web/src/modules/components/mainNavigationControl/mainNavigationControlDirective.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/mainNavigationControl/mainNavigationControlDirective.test.js
@@ -1,14 +1,14 @@
 describe('mainNavigationControl', function() {
   beforeEach(module('14c'));
 
-  var element, rootScope;
+  var element, rootScope, controller, mockNavService, mainNavigationControlController;
+
   beforeEach(function() {
     element = angular.element('<main-navigation-control/>');
     inject(function($rootScope, $compile, $document, navService, $controller) {
       rootScope = $rootScope.$new();
       controller = $controller
       mockNavService = navService;
-      mockDocument = $document;
       $compile(element)(rootScope);
       spyOn(mockNavService, 'gotoSection');
       mainNavigationControlController = function() {
@@ -28,7 +28,7 @@ describe('mainNavigationControl', function() {
   it('navs to section on keydown', function() {
     rootScope.$digest();
     expect(rootScope.clicked).toBeFalsy();
-    var controller = mainNavigationControlController();
+    mainNavigationControlController();
     var target = {
       dataset: {
         sectionid: 'work-sites'

--- a/DOL.WHD.Section14c.Web/src/modules/components/mainTopNavControl/mainTopNavControlController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/mainTopNavControl/mainTopNavControlController.test.js
@@ -1,5 +1,5 @@
 describe('mainTopNavControlController', function() {
-  var scope, mockLocation, mockStateService, mockAutoSaveService, mockNavService;
+  var scope, mockLocation, mockStateService, mockAutoSaveService;
   var mainTopNavControlController;
 
   beforeEach(module('14c'));

--- a/DOL.WHD.Section14c.Web/src/modules/components/sectionEmployer/sectionEmployerController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/sectionEmployer/sectionEmployerController.test.js
@@ -31,12 +31,12 @@ describe('sectionEmployerController', function() {
     scope.formData = {
       IsPointOfContact: true
     };
-    controller = sectionEmployerController();
+    sectionEmployerController();
     expect(scope.formData.employer).toBeDefined();
   });
 
   it('county is undefined when PA is selected as state', function() {
-    var controller = sectionEmployerController();
+    sectionEmployerController();
 
     scope.formData.employer.physicalAddress = {};
     scope.formData.employer.physicalAddress.state = 'PA';

--- a/DOL.WHD.Section14c.Web/src/modules/components/userRegistrationForm/userRegistrationFormController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/components/userRegistrationForm/userRegistrationFormController.test.js
@@ -1,6 +1,7 @@
 describe('userRegistrationFormController', function() {
   var $q, scope, mockapiService, mockLocation, formVals;
   var userRegistrationFormController, userRegister, emailVerification;
+  var checkPasswordComplexity;
 
   beforeEach(module('14c'));
 

--- a/DOL.WHD.Section14c.Web/src/modules/pages/employerRegistrationController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/pages/employerRegistrationController.test.js
@@ -1,5 +1,7 @@
 describe('employerRegistrationController', function() {
-  var scope, employerRegistrationController, organizations, formData, mockValidationService, mockStateService, $q, location;
+  var scope, employerRegistrationController, mockValidationService, $q;
+  var mockApiService, controller;
+  var setEmployer, validateEIN, validateZipCode, validateCertificateNumber;
 
   beforeEach(module('14c'));
 

--- a/DOL.WHD.Section14c.Web/src/modules/pages/landingPageController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/pages/landingPageController.test.js
@@ -1,17 +1,17 @@
 describe('landingPageController', function() {
-  var scope, landingPageController, mockAutoSaveService, mockLocation, organizations, mockApiService, mockStateService, $q, location;
+  var scope, landingPageController, mockAutoSaveService, mockLocation, mockApiService, mockStateService, $q;
+  var userInfo, clearApplication, downloadApplicationPdf, loadSavedApplication, saveNewApplication;
 
   beforeEach(module('14c'));
 
   beforeEach(
-    inject(function($rootScope, $controller, apiService, autoSaveService, $location, stateService, _$q_, $location) {
+    inject(function($rootScope, $controller, apiService, autoSaveService, $location, stateService, _$q_) {
       scope = $rootScope.$new();
       mockStateService = stateService;
       mockLocation = $location;
       mockAutoSaveService = autoSaveService;
       mockApiService = apiService;
       $q = _$q_;
-      location = $location
 
       landingPageController = function() {
         return $controller('landingPageController', {
@@ -23,7 +23,7 @@ describe('landingPageController', function() {
         });
       };
 
-      controller = landingPageController();
+      landingPageController();
       scope.orgMemberships = [
         {
           employer: {
@@ -270,10 +270,8 @@ describe('landingPageController', function() {
   });
 
   describe('has a table config...', function() {
-    var controller;
     beforeEach(function() {
-      controller = landingPageController();
-      // spyOn(mockDocument[0], 'getElementById');
+      landingPageController();
     });
     describe('with employee columns definition...', function() {
       it('converts the 4th column to "yes" for truthy values', function() {

--- a/DOL.WHD.Section14c.Web/src/modules/pages/systemUseController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/pages/systemUseController.test.js
@@ -1,15 +1,13 @@
 describe('systemUseController', function() {
-  var scope, systemUseController, organizations, mockLocation, mockStateService, $q, location;
+  var scope, systemUseController, mockLocation, mockStateService, controller;
 
   beforeEach(module('14c'));
 
   beforeEach(
-    inject(function($rootScope, $controller, stateService, $location, _$q_, $location) {
+    inject(function($rootScope, $controller, stateService, $location) {
       scope = $rootScope.$new();
       mockStateService = stateService;
       mockLocation = $location;
-      $q = _$q_;
-      location = $location
 
       systemUseController = function() {
         return $controller('systemUseController', {

--- a/DOL.WHD.Section14c.Web/src/modules/pages/userLoginPageController.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/pages/userLoginPageController.test.js
@@ -1,7 +1,6 @@
 describe('userLoginPageController', function() {
-  var scope, userLoginPageController;
-  var $q, scope, mockapiService, mockLocation, formVals;
-  var userLoginPageController, userRegister, emailVerification;
+  var $q, scope, mockapiService, mockLocation;
+  var userLoginPageController, emailVerification;
   beforeEach(module('14c'));
 
   beforeEach(
@@ -16,11 +15,7 @@ describe('userLoginPageController', function() {
       scope = $rootScope.$new();
       mockapiService = apiService;
       mockLocation = $location;
-      formVals = {
-        email: "test@tst.com",
-        firstName: "A",
-        lastName: "B"
-      }
+
       userLoginPageController = function() {
         return $controller('userLoginPageController', {
           $scope: scope,
@@ -46,7 +41,7 @@ describe('userLoginPageController', function() {
       code: 'code',
       userId: 'userId'
     });
-    var controller = userLoginPageController();
+    userLoginPageController();
     scope.$apply();
 
     expect(scope.isEmailVerificationRequest).toBe(true);
@@ -57,7 +52,7 @@ describe('userLoginPageController', function() {
       code: 'code',
       userId: 'userId'
     });
-    var controller = userLoginPageController();
+    userLoginPageController();
     emailVerification.resolve();
     scope.$apply();
 
@@ -69,7 +64,7 @@ describe('userLoginPageController', function() {
       code: 'code',
       userId: 'userId'
     });
-    var controller = userLoginPageController();
+    userLoginPageController();
     emailVerification.reject({});
     scope.$apply();
 
@@ -81,7 +76,7 @@ describe('userLoginPageController', function() {
       code: 'code',
       userId: 'userId'
     });
-    var controller = userLoginPageController();
+    userLoginPageController();
     emailVerification.reject({ data: { error: 'test' } });
     scope.$apply();
 

--- a/DOL.WHD.Section14c.Web/src/modules/services/apiService.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/services/apiService.test.js
@@ -5,10 +5,8 @@ describe('apiService', function() {
   beforeEach(module('14c'));
 
   beforeEach(
-    inject(function($injector, _$httpBackend_, apiService, moment, submissionService, _env) {
+    inject(function($injector, _$httpBackend_, apiService, _env) {
       api = apiService;
-      submissionService = submissionService;
-      moment = moment;
       $httpBackend = _$httpBackend_;
       env = _env;
     })

--- a/DOL.WHD.Section14c.Web/src/modules/services/authService.test.js
+++ b/DOL.WHD.Section14c.Web/src/modules/services/authService.test.js
@@ -181,8 +181,7 @@ describe('authService', function() {
     var result;
     var isResolved;
     var data = { organizations: [{ ein: '12-1234567', employer: {legalName: 'legalName'}, applicationId: '123' }]};
-    var loadSavedApplication = $q.defer();
-    authService.authenticateUser().then(undefined, function(error) {
+    authService.authenticateUser().then(undefined, function() {
       result = 'error';
       isResolved = false;
     });


### PR DESCRIPTION
#### What's this PR do?

Fixes the remaining lint errors, almost entire undefined variables in the tests.  Because of the way browsers parse JS and handle undefined variables (they define them on-the-spot), the tests worked fine, but a little code cleanup never hurt anyone.  😄

#### How should this be manually tested?

Verify the tests still run with `npm test`, and run `npm run lint` to see the clean results.