### PR TITLE
#141-fix

### DIFF
--- a/DOL.WHD.Section14c.Api/App_Data/AccountLockedOutEmailTemplate.txt
+++ b/DOL.WHD.Section14c.Api/App_Data/AccountLockedOutEmailTemplate.txt
@@ -1,3 +1,3 @@
-﻿Your account has been locked out for 15 minutes due to multiple failed login attempts.
+﻿Your account has been locked for 15 minutes due to multiple failed login attempts.
 
 Sincerely

--- a/DOL.WHD.Section14c.Api/App_GlobalResources/LocalizedText.Designer.cs
+++ b/DOL.WHD.Section14c.Api/App_GlobalResources/LocalizedText.Designer.cs
@@ -88,7 +88,7 @@ namespace DOL.WHD.Section14c.Api.App_GlobalResources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Your account has been locked out for {0} minutes due to multiple failed login attempts..
+        ///   Looks up a localized string similar to Your account has been locked for {0} minutes due to multiple failed login attempts..
         /// </summary>
         internal static string LoginFailureMessageAccountLockedOut {
             get {

--- a/DOL.WHD.Section14c.Api/App_GlobalResources/LocalizedText.resx
+++ b/DOL.WHD.Section14c.Api/App_GlobalResources/LocalizedText.resx
@@ -127,7 +127,7 @@
     <value>Login failure</value>
   </data>
   <data name="LoginFailureMessageAccountLockedOut" xml:space="preserve">
-    <value>Your account has been locked out for {0} minutes due to multiple failed login attempts.</value>
+    <value>Your account has been locked for {0} minutes due to multiple failed login attempts.</value>
   </data>
   <data name="LoginFailureMessageEmailNotConfirmed" xml:space="preserve">
     <value>Email not confirmed</value>


### PR DESCRIPTION
Can we please tweak the language slightly? Remove "out", so that it reads, "Your account has been locked for 15 minutes due to multiple failed login attempts." #141